### PR TITLE
Service waf enable

### DIFF
--- a/fastly/block_fastly_service_v1_waf.go
+++ b/fastly/block_fastly_service_v1_waf.go
@@ -49,7 +49,6 @@ func processWAF(d *schema.ResourceData, conn *gofastly.Client, v int) error {
 		}
 
 		log.Printf("[DEBUG] Fastly WAF update opts: %#v", opts)
-
 		// check if WAF exists first
 		if !wAFExists(conn, gofastly.GetWAFInput{
 			Version: serviceVersion,
@@ -74,19 +73,16 @@ func processWAF(d *schema.ResourceData, conn *gofastly.Client, v int) error {
 			return err
 		}
 
-		log.Printf("[DEBUG] Fastly WAF addition opts: %#v", opts)
 		if err := createWAF(wf, conn, opts); err != nil {
 			return err
 		}
 
 	} else if len(oldWAFVal.([]interface{})) > 0 {
-
-		log.Printf("[DEBUG] deleting WAF")
-		df := oldWAFVal.([]interface{})[0].(map[string]interface{})
+		wf := oldWAFVal.([]interface{})[0].(map[string]interface{})
 
 		opts := gofastly.DeleteWAFInput{
 			Version: serviceVersion,
-			ID:      df["waf_id"].(string),
+			ID:      wf["waf_id"].(string),
 		}
 
 		log.Printf("[DEBUG] Fastly WAF Removal opts: %#v", opts)

--- a/fastly/block_fastly_service_v1_waf.go
+++ b/fastly/block_fastly_service_v1_waf.go
@@ -9,7 +9,7 @@ import (
 )
 
 // WAFSchema the WAF block schema
-var WAFSchema = &schema.Schema{
+var wafSchema = &schema.Schema{
 	Type:     schema.TypeList,
 	Optional: true,
 	MaxItems: 1,
@@ -50,7 +50,7 @@ func processWAF(d *schema.ResourceData, conn *gofastly.Client, v int) error {
 
 		log.Printf("[DEBUG] Fastly WAF update opts: %#v", copts)
 		// check if WAF exists first
-		if !wAFExists(conn, gofastly.GetWAFInput{
+		if !wafExists(conn, gofastly.GetWAFInput{
 			Version: serviceVersion,
 			Service: serviceID,
 			ID:      wf["waf_id"].(string),
@@ -114,7 +114,7 @@ func createWAF(df map[string]interface{}, conn *gofastly.Client, i *gofastly.Cre
 	return nil
 }
 
-func wAFExists(conn *gofastly.Client, i gofastly.GetWAFInput) bool {
+func wafExists(conn *gofastly.Client, i gofastly.GetWAFInput) bool {
 
 	_, err := conn.GetWAF(&i)
 	if err != nil {
@@ -158,8 +158,8 @@ func buildCreateWAF(WAFMap interface{}, serviceID string, ServiceVersion string)
 	return &opts, nil
 }
 
-func buildUpdateWAF(WAFMap interface{}, serviceID string, ServiceVersion string) (*gofastly.UpdateWAFInput, error) {
-	df := WAFMap.(map[string]interface{})
+func buildUpdateWAF(wafMap interface{}, serviceID string, ServiceVersion string) (*gofastly.UpdateWAFInput, error) {
+	df := wafMap.(map[string]interface{})
 	opts := gofastly.UpdateWAFInput{
 		Service:           serviceID,
 		Version:           ServiceVersion,

--- a/fastly/block_fastly_service_v1_waf.go
+++ b/fastly/block_fastly_service_v1_waf.go
@@ -1,6 +1,7 @@
 package fastly
 
 import (
+	"fmt"
 	"log"
 	"strconv"
 
@@ -40,48 +41,22 @@ func processWAF(d *schema.ResourceData, conn *gofastly.Client, v int) error {
 	serviceVersion := strconv.Itoa(v)
 	oldWAFVal, newWAFVal := d.GetChange("waf")
 
-	if len(oldWAFVal.([]interface{})) > 0 && len(newWAFVal.([]interface{})) > 0 {
+	if len(newWAFVal.([]interface{})) > 0 {
 		wf := newWAFVal.([]interface{})[0].(map[string]interface{})
-		copts, err := buildCreateWAF(wf, serviceID, serviceVersion)
-		if err != nil {
-			log.Printf("[DEBUG] Error building create WAF input: %s", err)
-			return err
-		}
-
-		log.Printf("[DEBUG] Fastly WAF update opts: %#v", copts)
-		// check if WAF exists first
-		if !wafExists(conn, gofastly.GetWAFInput{
-			Version: serviceVersion,
-			Service: serviceID,
-			ID:      wf["waf_id"].(string),
-		}) {
-			log.Printf("[WARN] WAF not found, creating one with update opts: %#v", copts)
-			if err := createWAF(wf, conn, copts); err != nil {
+		if !wafExists(conn, serviceID, serviceVersion, wf["waf_id"].(string)) {
+			opts := buildCreateWAF(wf, serviceID, serviceVersion)
+			log.Printf("[WARN] WAF not found, creating one with update opts: %#v", opts)
+			if err := createWAF(wf, conn, opts); err != nil {
+				return err
+			}
+		} else {
+			opts := buildUpdateWAF(wf, serviceID, serviceVersion)
+			log.Printf("[DEBUG] Fastly WAF update opts: %#v", opts)
+			_, err := conn.UpdateWAF(opts)
+			if err != nil {
 				return err
 			}
 		}
-		uopts, err := buildUpdateWAF(wf, serviceID, serviceVersion)
-		if err != nil {
-			log.Printf("[DEBUG] Error building update WAF input: %s", err)
-			return err
-		}
-		_, err = conn.UpdateWAF(uopts)
-		if err != nil {
-			return err
-		}
-
-	} else if len(newWAFVal.([]interface{})) > 0 {
-		wf := newWAFVal.([]interface{})[0].(map[string]interface{})
-		opts, err := buildCreateWAF(wf, serviceID, serviceVersion)
-		if err != nil {
-			log.Printf("[DEBUG] Error building WAF: %s", err)
-			return err
-		}
-
-		if err := createWAF(wf, conn, opts); err != nil {
-			return err
-		}
-
 	} else if len(oldWAFVal.([]interface{})) > 0 {
 		wf := oldWAFVal.([]interface{})[0].(map[string]interface{})
 
@@ -89,7 +64,6 @@ func processWAF(d *schema.ResourceData, conn *gofastly.Client, v int) error {
 			Version: serviceVersion,
 			ID:      wf["waf_id"].(string),
 		}
-
 		log.Printf("[DEBUG] Fastly WAF Removal opts: %#v", opts)
 		err := conn.DeleteWAF(&opts)
 		if errRes, ok := err.(*gofastly.HTTPError); ok {
@@ -99,6 +73,25 @@ func processWAF(d *schema.ResourceData, conn *gofastly.Client, v int) error {
 		} else if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func readWAF(conn *gofastly.Client, d *schema.ResourceData, s *gofastly.ServiceDetail) error {
+	// refresh WAFs
+	log.Printf("[DEBUG] Refreshing WAFs for (%s)", d.Id())
+	wafList, err := conn.ListWAFs(&gofastly.ListWAFsInput{
+		FilterService: d.Id(),
+		FilterVersion: s.ActiveVersion.Number,
+	})
+	if err != nil {
+		return fmt.Errorf("[ERR] Error looking up WAFs for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+	}
+
+	waf := flattenWAFs(wafList.Items)
+
+	if err := d.Set("waf", waf); err != nil {
+		log.Printf("[WARN] Error setting waf for (%s): %s", d.Id(), err)
 	}
 	return nil
 }
@@ -114,9 +107,13 @@ func createWAF(df map[string]interface{}, conn *gofastly.Client, i *gofastly.Cre
 	return nil
 }
 
-func wafExists(conn *gofastly.Client, i gofastly.GetWAFInput) bool {
+func wafExists(conn *gofastly.Client, s, v, id string) bool {
 
-	_, err := conn.GetWAF(&i)
+	_, err := conn.GetWAF(&gofastly.GetWAFInput{
+		Service: s,
+		Version: v,
+		ID:      id,
+	})
 	if err != nil {
 		return false
 	}
@@ -146,7 +143,7 @@ func flattenWAFs(wafList []*gofastly.WAF) []map[string]interface{} {
 	return append(wl, WAFMapString)
 }
 
-func buildCreateWAF(WAFMap interface{}, serviceID string, ServiceVersion string) (*gofastly.CreateWAFInput, error) {
+func buildCreateWAF(WAFMap interface{}, serviceID string, ServiceVersion string) *gofastly.CreateWAFInput {
 	df := WAFMap.(map[string]interface{})
 	opts := gofastly.CreateWAFInput{
 		Service:           serviceID,
@@ -155,10 +152,10 @@ func buildCreateWAF(WAFMap interface{}, serviceID string, ServiceVersion string)
 		PrefetchCondition: df["prefetch_condition"].(string),
 		Response:          df["response_object"].(string),
 	}
-	return &opts, nil
+	return &opts
 }
 
-func buildUpdateWAF(wafMap interface{}, serviceID string, ServiceVersion string) (*gofastly.UpdateWAFInput, error) {
+func buildUpdateWAF(wafMap interface{}, serviceID string, ServiceVersion string) *gofastly.UpdateWAFInput {
 	df := wafMap.(map[string]interface{})
 	opts := gofastly.UpdateWAFInput{
 		Service:           serviceID,
@@ -167,5 +164,5 @@ func buildUpdateWAF(wafMap interface{}, serviceID string, ServiceVersion string)
 		PrefetchCondition: df["prefetch_condition"].(string),
 		Response:          df["response_object"].(string),
 	}
-	return &opts, nil
+	return &opts
 }

--- a/fastly/block_fastly_service_v1_waf_test.go
+++ b/fastly/block_fastly_service_v1_waf_test.go
@@ -160,8 +160,8 @@ func testAccCheckFastlyServiceV1DeletedWAF(service *gofastly.ServiceDetail) reso
 
 		conn := testAccProvider.Meta().(*FastlyClient).conn
 		wafs, err := conn.ListWAFs(&gofastly.ListWAFsInput{
-			Service: service.ID,
-			Version: strconv.Itoa(service.ActiveVersion.Number),
+			FilterService: service.ID,
+			FilterVersion: service.ActiveVersion.Number,
 		})
 		if err != nil {
 			return err
@@ -183,8 +183,8 @@ func testAccCheckFastlyServiceV1AttributesWAF(service *gofastly.ServiceDetail, n
 
 		conn := testAccProvider.Meta().(*FastlyClient).conn
 		wafs, err := conn.ListWAFs(&gofastly.ListWAFsInput{
-			Service: service.ID,
-			Version: strconv.Itoa(service.ActiveVersion.Number),
+			FilterService: service.ID,
+			FilterVersion: service.ActiveVersion.Number,
 		})
 
 		waf, err := conn.GetWAF(&gofastly.GetWAFInput{

--- a/fastly/block_fastly_service_v1_waf_test.go
+++ b/fastly/block_fastly_service_v1_waf_test.go
@@ -1,0 +1,258 @@
+package fastly
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"testing"
+
+	gofastly "github.com/fastly/go-fastly/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+var serviceRef = "fastly_service_v1.foo"
+var condition = "prefetch"
+var response = "response"
+
+func TestResourceFastlyFlattenWAF(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.WAF
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.WAF{
+				{
+					ID:                "test1",
+					PrefetchCondition: "prefetch",
+					Response:          "response",
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"waf_id":             "test1",
+					"prefetch_condition": "prefetch",
+					"response_object":    "response",
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		out := flattenWAFs(c.remote)
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n     got: %#v", c.local, out)
+		}
+	}
+}
+
+func TestAccFastlyServiceV1WAFAdd(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1(name, response, condition, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists(serviceRef, &service),
+					testAccCheckFastlyServiceV1AttributesWAF(&service, name, response, condition),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceV1WAFAddAndRemove(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1(name, response, condition, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists(serviceRef, &service),
+				),
+			},
+			{
+				Config: testAccServiceV1(name, response, condition, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists(serviceRef, &service),
+					testAccCheckFastlyServiceV1AttributesWAF(&service, name, response, condition),
+				),
+			},
+			{
+				Config: testAccServiceV1(name, response, condition, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists(serviceRef, &service),
+					testAccCheckFastlyServiceV1DeletedWAF(&service),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceV1WAFUpdateResponse(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	updateResponse := "UpdatedResponse"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1(name, response, condition, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists(serviceRef, &service),
+					testAccCheckFastlyServiceV1AttributesWAF(&service, name, response, condition),
+				),
+			},
+			{
+				Config: testAccServiceV1(name, updateResponse, condition, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists(serviceRef, &service),
+					testAccCheckFastlyServiceV1AttributesWAF(&service, name, updateResponse, condition),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFastlyServiceV1WAFUpdateCondition(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	updatedCondition := "UpdatedPrefetch"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceV1(name, response, condition, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists(serviceRef, &service),
+					testAccCheckFastlyServiceV1AttributesWAF(&service, name, response, condition),
+				),
+			},
+			{
+				Config: testAccServiceV1(name, response, updatedCondition, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists(serviceRef, &service),
+					testAccCheckFastlyServiceV1AttributesWAF(&service, name, response, updatedCondition),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceV1DeletedWAF(service *gofastly.ServiceDetail) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		wafs, err := conn.ListWAFs(&gofastly.ListWAFsInput{
+			Service: service.ID,
+			Version: strconv.Itoa(service.ActiveVersion.Number),
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(wafs) > 0 {
+			return fmt.Errorf("[ERR] Error WAF %s should not be present for (%s), version (%v): %s", wafs[0].ID, service.ID, service.ActiveVersion.Number, err)
+		}
+		return nil
+	}
+}
+
+func testAccCheckFastlyServiceV1AttributesWAF(service *gofastly.ServiceDetail, name, response, condition string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if service.Name != name {
+			return fmt.Errorf("Bad name, expected (%s), got (%s)", name, service.Name)
+		}
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		wafs, err := conn.ListWAFs(&gofastly.ListWAFsInput{
+			Service: service.ID,
+			Version: strconv.Itoa(service.ActiveVersion.Number),
+		})
+
+		waf, err := conn.GetWAF(&gofastly.GetWAFInput{
+			Service: service.ID,
+			Version: strconv.Itoa(service.ActiveVersion.Number),
+			ID:      wafs[0].ID,
+		})
+
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up WAF records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if waf.Response != response {
+			return fmt.Errorf("WAF response mismatch, expected: %s, got: %#v", response, waf.Response)
+		}
+
+		if waf.PrefetchCondition != condition {
+			return fmt.Errorf("WAF condition mismatch, expected: %#v, got: %#v", condition, waf.PrefetchCondition)
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceV1(name, response, condition string, withWAF bool) string {
+
+	var waf string
+	if withWAF {
+		waf = fmt.Sprintf(`
+		waf { 
+			prefetch_condition = "%s" 
+			response_object = "%s"
+		}`, condition, response)
+	}
+
+	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	domainName := fmt.Sprintf("fastly-test.tf-%s.com", acctest.RandString(10))
+
+	return fmt.Sprintf(`
+resource "fastly_service_v1" "foo" {
+  name = "%s"
+
+  domain {
+    name    = "%s"
+    comment = "tf-testing-domain"
+  }
+
+  backend {
+    address = "%s"
+    name    = "tf -test backend"
+  }
+
+  condition {
+	name = "%s"
+	type = "PREFETCH"
+	statement = "req.url~+\"index.html\""
+  }
+
+  response_object {
+	name = "%s"
+	status = "403"
+	response = "Forbidden"
+	content = "content"
+  }
+
+  %s
+
+  force_destroy = true
+}`, name, domainName, backendName, condition, response, waf)
+
+}

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -3650,22 +3650,10 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 			log.Printf("[WARN] Error setting Dictionary for (%s): %s", d.Id(), err)
 		}
 
-		// refresh WAFs
-		log.Printf("[DEBUG] Refreshing WAFs for (%s)", d.Id())
-		wafList, err := conn.ListWAFs(&gofastly.ListWAFsInput{
-			FilterService: d.Id(),
-			FilterVersion: s.ActiveVersion.Number,
-		})
-		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up WAFs for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+		// refresh WAF
+		if err := readWAF(conn, d, s); err != nil {
+			return err
 		}
-
-		waf := flattenWAFs(wafList.Items)
-
-		if err := d.Set("waf", waf); err != nil {
-			log.Printf("[WARN] Error setting waf for (%s): %s", d.Id(), err)
-		}
-
 	} else {
 		log.Printf("[DEBUG] Active Version for Service (%s) is empty, no state to refresh", d.Id())
 	}

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strconv"
 	"strings"
 	"time"
 
@@ -3669,8 +3668,8 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		// refresh WAFs
 		log.Printf("[DEBUG] Refreshing WAFs for (%s)", d.Id())
 		wafList, err := conn.ListWAFs(&gofastly.ListWAFsInput{
-			Service: d.Id(),
-			Version: strconv.Itoa(s.ActiveVersion.Number),
+			FilterService: d.Id(),
+			FilterVersion: s.ActiveVersion.Number,
 		})
 		if err != nil {
 			return fmt.Errorf("[ERR] Error looking up WAFs for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -1472,7 +1472,7 @@ func resourceServiceV1() *schema.Resource {
 					},
 				},
 			},
-			"waf": WAFSchema,
+			"waf": wafSchema,
 		},
 	}
 }
@@ -3194,50 +3194,6 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return resourceServiceV1Read(d, meta)
-}
-
-func deleteResponses(responsesToDelete []interface{}, conn *gofastly.Client, serviceID string, serviceVersion int) error {
-	for _, rRaw := range responsesToDelete {
-		rf := rRaw.(map[string]interface{})
-		opts := gofastly.DeleteResponseObjectInput{
-			Service: serviceID,
-			Version: serviceVersion,
-			Name:    rf["name"].(string),
-		}
-
-		log.Printf("[DEBUG] Fastly Response Object removal opts: %#v", opts)
-		err := conn.DeleteResponseObject(&opts)
-		if errRes, ok := err.(*gofastly.HTTPError); ok {
-			if errRes.StatusCode != 404 {
-				return err
-			}
-		} else if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func deleteConditions(conditionsToRemove []interface{}, conn *gofastly.Client, serviceID string, serviceVersion int) error {
-	for _, cRaw := range conditionsToRemove {
-		cf := cRaw.(map[string]interface{})
-		opts := gofastly.DeleteConditionInput{
-			Service: serviceID,
-			Version: serviceVersion,
-			Name:    cf["name"].(string),
-		}
-
-		log.Printf("[DEBUG] Fastly Conditions Removal opts: %#v", opts)
-		err := conn.DeleteCondition(&opts)
-		if errRes, ok := err.(*gofastly.HTTPError); ok {
-			if errRes.StatusCode != 404 {
-				return err
-			}
-		} else if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {

--- a/fastly/resource_fastly_service_v1.go
+++ b/fastly/resource_fastly_service_v1.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1472,6 +1473,7 @@ func resourceServiceV1() *schema.Resource {
 					},
 				},
 			},
+			"waf": WAFSchema,
 		},
 	}
 }
@@ -1546,6 +1548,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		"vcl",
 		"acl",
 		"dictionary",
+		"waf",
 	} {
 		if d.HasChange(v) {
 			needsChange = true
@@ -1642,6 +1645,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		// configuraiton objects (Backends, Request Headers, etc)
 
 		// Find difference in Conditions
+		var removeConditions []interface{}
 		if d.HasChange("condition") {
 			// Note: we don't utilize the PUT endpoint to update these objects, we simply
 			// destroy any that have changed, and create new ones with the updated
@@ -1659,28 +1663,8 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 
 			ocs := oc.(*schema.Set)
 			ncs := nc.(*schema.Set)
-			removeConditions := ocs.Difference(ncs).List()
+			removeConditions = ocs.Difference(ncs).List()
 			addConditions := ncs.Difference(ocs).List()
-
-			// DELETE old Conditions
-			for _, cRaw := range removeConditions {
-				cf := cRaw.(map[string]interface{})
-				opts := gofastly.DeleteConditionInput{
-					Service: d.Id(),
-					Version: latestVersion,
-					Name:    cf["name"].(string),
-				}
-
-				log.Printf("[DEBUG] Fastly Conditions Removal opts: %#v", opts)
-				err := conn.DeleteCondition(&opts)
-				if errRes, ok := err.(*gofastly.HTTPError); ok {
-					if errRes.StatusCode != 404 {
-						return err
-					}
-				} else if err != nil {
-					return err
-				}
-			}
 
 			// POST new Conditions
 			for _, cRaw := range addConditions {
@@ -2689,6 +2673,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		// find difference in Response Object
+		var removeResponseObject []interface{}
 		if d.HasChange("response_object") {
 			or, nr := d.GetChange("response_object")
 			if or == nil {
@@ -2700,28 +2685,8 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 
 			ors := or.(*schema.Set)
 			nrs := nr.(*schema.Set)
-			removeResponseObject := ors.Difference(nrs).List()
+			removeResponseObject = ors.Difference(nrs).List()
 			addResponseObject := nrs.Difference(ors).List()
-
-			// DELETE old response object configurations
-			for _, rRaw := range removeResponseObject {
-				rf := rRaw.(map[string]interface{})
-				opts := gofastly.DeleteResponseObjectInput{
-					Service: d.Id(),
-					Version: latestVersion,
-					Name:    rf["name"].(string),
-				}
-
-				log.Printf("[DEBUG] Fastly Response Object removal opts: %#v", opts)
-				err := conn.DeleteResponseObject(&opts)
-				if errRes, ok := err.(*gofastly.HTTPError); ok {
-					if errRes.StatusCode != 404 {
-						return err
-					}
-				} else if err != nil {
-					return err
-				}
-			}
 
 			// POST new/updated Response Object
 			for _, rRaw := range addResponseObject {
@@ -3147,6 +3112,22 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
+		// Find differences in WAF
+		if d.HasChange("waf") {
+			if err := processWAF(d, conn, latestVersion); err != nil {
+				return err
+			}
+		}
+		// The deletion of response objects and condition is done after any updates on the waf block. this is
+		// because those 2 objects can't be deleted while referenced by the waf
+		if err := deleteResponses(removeResponseObject, conn, d.Id(), latestVersion); err != nil {
+			return err
+		}
+
+		if err := deleteConditions(removeConditions, conn, d.Id(), latestVersion); err != nil {
+			return err
+		}
+
 		// validate version
 		log.Printf("[DEBUG] Validating Fastly Service (%s), Version (%v)", d.Id(), latestVersion)
 		valid, msg, err := conn.ValidateVersion(&gofastly.ValidateVersionInput{
@@ -3185,6 +3166,50 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return resourceServiceV1Read(d, meta)
+}
+
+func deleteResponses(responsesToDelete []interface{}, conn *gofastly.Client, serviceID string, serviceVersion int) error {
+	for _, rRaw := range responsesToDelete {
+		rf := rRaw.(map[string]interface{})
+		opts := gofastly.DeleteResponseObjectInput{
+			Service: serviceID,
+			Version: serviceVersion,
+			Name:    rf["name"].(string),
+		}
+
+		log.Printf("[DEBUG] Fastly Response Object removal opts: %#v", opts)
+		err := conn.DeleteResponseObject(&opts)
+		if errRes, ok := err.(*gofastly.HTTPError); ok {
+			if errRes.StatusCode != 404 {
+				return err
+			}
+		} else if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteConditions(conditionsToRemove []interface{}, conn *gofastly.Client, serviceID string, serviceVersion int) error {
+	for _, cRaw := range conditionsToRemove {
+		cf := cRaw.(map[string]interface{})
+		opts := gofastly.DeleteConditionInput{
+			Service: serviceID,
+			Version: serviceVersion,
+			Name:    cf["name"].(string),
+		}
+
+		log.Printf("[DEBUG] Fastly Conditions Removal opts: %#v", opts)
+		err := conn.DeleteCondition(&opts)
+		if errRes, ok := err.(*gofastly.HTTPError); ok {
+			if errRes.StatusCode != 404 {
+				return err
+			}
+		} else if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
@@ -3639,6 +3664,22 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 
 		if err := d.Set("dictionary", dict); err != nil {
 			log.Printf("[WARN] Error setting Dictionary for (%s): %s", d.Id(), err)
+		}
+
+		// refresh WAFs
+		log.Printf("[DEBUG] Refreshing WAFs for (%s)", d.Id())
+		wafList, err := conn.ListWAFs(&gofastly.ListWAFsInput{
+			Service: d.Id(),
+			Version: strconv.Itoa(s.ActiveVersion.Number),
+		})
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up WAFs for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
+		}
+
+		waf := flattenWAFs(wafList)
+
+		if err := d.Set("waf", waf); err != nil {
+			log.Printf("[WARN] Error setting waf for (%s): %s", d.Id(), err)
 		}
 
 	} else {


### PR DESCRIPTION
This PR contains the implementation of the waf component within a service. This implementation hasn't been done in the traditional way of adding service components, but it is extracted to a dedicated file which includes exclusively waf related code.

Acceptance and unit tests have been added following the structure of existing components such as dictionaries.

Response objects and conditions deletion has been moved down to be executed after any potential waf updates. The reason for this is the following; in the case of updating the reference (name) of any of those waf dependencies, for example the condition, the condition will not be update but replaced with a new one, and deleting a condition while attached to a WAF is not allowed by the API.