### PR TITLE
Waf disable enable

### DIFF
--- a/fastly/block_fastly_service_v1_waf.go
+++ b/fastly/block_fastly_service_v1_waf.go
@@ -53,7 +53,7 @@ func processWAF(d *schema.ResourceData, conn *gofastly.Client, v int) error {
 
 		var err error
 		var waf *gofastly.WAF
-		if ok := wafExists(conn, serviceID, serviceVersion, wf["waf_id"].(string)); ok {
+		if wafExists(conn, serviceID, serviceVersion, wf["waf_id"].(string)) {
 			opts := buildUpdateWAF(wf, serviceID, serviceVersion)
 			log.Printf("[DEBUG] Fastly WAF update opts: %#v", opts)
 			waf, err = conn.UpdateWAF(opts)


### PR DESCRIPTION
This PR contains the terraform implementation of a disabled flag within the Fastly service WAF component. When the disabled is on, the service WAF becomes inactive, but no other configuration is altered. When the disabled flag is not present the "false" default is applied. 