### PR TITLE
Terraform conventions

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,7 +17,7 @@ test: fmtcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m -ldflags="-X=$(FULL_PKG_NAME)/$(VERSION_PLACEHOLDER)=acc"
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m -parallel 8 -ldflags="-X=$(FULL_PKG_NAME)/$(VERSION_PLACEHOLDER)=acc"
 
 vet:
 	@echo "go vet ."

--- a/fastly/block_fastly_service_v1_waf_test.go
+++ b/fastly/block_fastly_service_v1_waf_test.go
@@ -62,13 +62,11 @@ func TestResourceFastlyFlattenWAF(t *testing.T) {
 }
 
 func TestAccFastlyServiceV1WAFAdd(t *testing.T) {
-	t.Parallel()
-
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	waf := composeWAF(condition, response, false)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -85,13 +83,11 @@ func TestAccFastlyServiceV1WAFAdd(t *testing.T) {
 }
 
 func TestAccFastlyServiceV1WAFAddAndRemove(t *testing.T) {
-	t.Parallel()
-
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	waf := composeWAF(condition, response, false)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -121,15 +117,13 @@ func TestAccFastlyServiceV1WAFAddAndRemove(t *testing.T) {
 }
 
 func TestAccFastlyServiceV1WAFUpdateResponse(t *testing.T) {
-	t.Parallel()
-
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	updateResponse := "UpdatedResponse"
 	waf := composeWAF(condition, response, false)
 	updatedWaf := composeWAF(condition, updateResponse, false)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -153,15 +147,13 @@ func TestAccFastlyServiceV1WAFUpdateResponse(t *testing.T) {
 }
 
 func TestAccFastlyServiceV1WAFUpdateCondition(t *testing.T) {
-	t.Parallel()
-
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	updatedCondition := "UpdatedPrefetch"
 	waf := composeWAF(condition, response, false)
 	updatedWaf := composeWAF(updatedCondition, response, false)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -185,8 +177,6 @@ func TestAccFastlyServiceV1WAFUpdateCondition(t *testing.T) {
 }
 
 func TestAccFastlyServiceV1WAFDisableEnable(t *testing.T) {
-	t.Parallel()
-
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	wafEnabled := composeWAF(condition, response, false)
@@ -201,7 +191,7 @@ func TestAccFastlyServiceV1WAFDisableEnable(t *testing.T) {
 		},
 	})
 	wafConfig := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF1)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_service_v1_waf_test.go
+++ b/fastly/block_fastly_service_v1_waf_test.go
@@ -62,6 +62,8 @@ func TestResourceFastlyFlattenWAF(t *testing.T) {
 }
 
 func TestAccFastlyServiceV1WAFAdd(t *testing.T) {
+	t.Parallel()
+
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	waf := composeWAF(condition, response, false)
@@ -83,6 +85,8 @@ func TestAccFastlyServiceV1WAFAdd(t *testing.T) {
 }
 
 func TestAccFastlyServiceV1WAFAddAndRemove(t *testing.T) {
+	t.Parallel()
+
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	waf := composeWAF(condition, response, false)
@@ -117,6 +121,8 @@ func TestAccFastlyServiceV1WAFAddAndRemove(t *testing.T) {
 }
 
 func TestAccFastlyServiceV1WAFUpdateResponse(t *testing.T) {
+	t.Parallel()
+
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	updateResponse := "UpdatedResponse"
@@ -147,6 +153,8 @@ func TestAccFastlyServiceV1WAFUpdateResponse(t *testing.T) {
 }
 
 func TestAccFastlyServiceV1WAFUpdateCondition(t *testing.T) {
+	t.Parallel()
+
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	updatedCondition := "UpdatedPrefetch"
@@ -177,6 +185,8 @@ func TestAccFastlyServiceV1WAFUpdateCondition(t *testing.T) {
 }
 
 func TestAccFastlyServiceV1WAFDisableEnable(t *testing.T) {
+	t.Parallel()
+
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	wafEnabled := composeWAF(condition, response, false)

--- a/fastly/block_fastly_waf_configuration_v1_active_rule.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule.go
@@ -50,6 +50,7 @@ func updateRules(d *schema.ResourceData, meta interface{}, wafID string, Number 
 	remove := oss.Difference(nss).List()
 	add := nss.Difference(oss).List()
 
+	log.Print("[INFO] WAF rules update")
 	if len(remove) > 0 {
 		deleteOpts := buildBatchDeleteWAFActiveRulesInput(remove, wafID, Number)
 		log.Printf("[DEBUG] WAF rules delete opts: %#v", deleteOpts)
@@ -76,6 +77,7 @@ func readWAFRules(meta interface{}, d *schema.ResourceData, v int) error {
 	conn := meta.(*FastlyClient).conn
 	wafID := d.Get("waf_id").(string)
 
+	log.Printf("[INFO] retrieving active rules for WAF: %s", wafID)
 	resp, err := conn.ListAllWAFActiveRules(&gofastly.ListAllWAFActiveRulesInput{
 		WAFID:            wafID,
 		WAFVersionNumber: v,

--- a/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
@@ -43,8 +43,6 @@ func TestAccFastlyServiceWAFVersionV1FlattenWAFActiveRules(t *testing.T) {
 }
 
 func TestAccFastlyServiceWAFVersionV1AddWithRules(t *testing.T) {
-	t.Parallel()
-
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -64,7 +62,7 @@ func TestAccFastlyServiceWAFVersionV1AddWithRules(t *testing.T) {
 	rulesTF := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules)
 	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -81,8 +79,6 @@ func TestAccFastlyServiceWAFVersionV1AddWithRules(t *testing.T) {
 }
 
 func TestAccFastlyServiceWAFVersionV1UpdateRules(t *testing.T) {
-	t.Parallel()
-
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -117,7 +113,7 @@ func TestAccFastlyServiceWAFVersionV1UpdateRules(t *testing.T) {
 	rulesTF2 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules2)
 	wafVer2 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF2)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -141,8 +137,6 @@ func TestAccFastlyServiceWAFVersionV1UpdateRules(t *testing.T) {
 }
 
 func TestAccFastlyServiceWAFVersionV1DeleteRules(t *testing.T) {
-	t.Parallel()
-
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -172,7 +166,7 @@ func TestAccFastlyServiceWAFVersionV1DeleteRules(t *testing.T) {
 	rulesTF2 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules2)
 	wafVer2 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF2)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,

--- a/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
@@ -43,6 +43,8 @@ func TestAccFastlyServiceWAFVersionV1FlattenWAFActiveRules(t *testing.T) {
 }
 
 func TestAccFastlyServiceWAFVersionV1AddWithRules(t *testing.T) {
+	t.Parallel()
+
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -79,6 +81,8 @@ func TestAccFastlyServiceWAFVersionV1AddWithRules(t *testing.T) {
 }
 
 func TestAccFastlyServiceWAFVersionV1UpdateRules(t *testing.T) {
+	t.Parallel()
+
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -137,6 +141,8 @@ func TestAccFastlyServiceWAFVersionV1UpdateRules(t *testing.T) {
 }
 
 func TestAccFastlyServiceWAFVersionV1DeleteRules(t *testing.T) {
+	t.Parallel()
+
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 

--- a/fastly/data_source_waf_rules.go
+++ b/fastly/data_source_waf_rules.go
@@ -89,7 +89,7 @@ func dataSourceFastlyWAFRulesRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	log.Printf("[DEBUG] Reading WAF rules")
+	log.Printf("[DEBUG] Reading WAF rules with ops: %#v", input)
 	res, err := conn.ListAllWAFRules(input)
 	if err != nil {
 		return fmt.Errorf("error listing WAF rules: %s", err)

--- a/fastly/data_source_waf_rules.go
+++ b/fastly/data_source_waf_rules.go
@@ -89,7 +89,7 @@ func dataSourceFastlyWAFRulesRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	log.Printf("[DEBUG] Reading WAF rules with ops: %#v", input)
+	log.Printf("[INFO] Reading WAF rules with ops: %#v", input)
 	res, err := conn.ListAllWAFRules(input)
 	if err != nil {
 		return fmt.Errorf("error listing WAF rules: %s", err)

--- a/fastly/resource_fastly_service_waf_configuration_v1.go
+++ b/fastly/resource_fastly_service_waf_configuration_v1.go
@@ -69,7 +69,6 @@ func resourceServiceWAFConfigurationV1() *schema.Resource {
 			"crs_validate_utf8_encoding": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
 				Description: "CRS validate UTF8 encoding.",
 			},
 			"error_anomaly_score": {

--- a/fastly/resource_fastly_service_waf_configuration_v1.go
+++ b/fastly/resource_fastly_service_waf_configuration_v1.go
@@ -305,9 +305,6 @@ func buildUpdateInput(d *schema.ResourceData, id string, number int) *gofastly.U
 	if v, ok := d.GetOk("allowed_methods"); ok {
 		input.AllowedMethods = v.(string)
 	}
-	if v, ok := d.GetOk("allowed_methods"); ok {
-		input.AllowedMethods = v.(string)
-	}
 	if v, ok := d.GetOk("allowed_request_content_type"); ok {
 		input.AllowedRequestContentType = v.(string)
 	}
@@ -391,93 +388,89 @@ func buildUpdateInput(d *schema.ResourceData, id string, number int) *gofastly.U
 
 func refreshWAFConfig(d *schema.ResourceData, version *gofastly.WAFVersion) {
 
-	d.SetId(version.ID)
-	if v, ok := d.GetOk("allowed_http_versions"); ok {
-		d.Set("allowed_http_versions", v)
+	if _, ok := d.GetOk("allowed_http_versions"); ok {
+		d.Set("allowed_http_versions", version.AllowedHTTPVersions)
 	}
-	if v, ok := d.GetOk("allowed_methods"); ok {
-		d.Set("allowed_methods", v)
+	if _, ok := d.GetOk("allowed_methods"); ok {
+		d.Set("allowed_methods", version.AllowedMethods)
 	}
-	if v, ok := d.GetOk("allowed_methods"); ok {
-		d.Set("allowed_methods", v)
+	if _, ok := d.GetOk("allowed_request_content_type"); ok {
+		d.Set("allowed_request_content_type", version.AllowedRequestContentType)
 	}
-	if v, ok := d.GetOk("allowed_request_content_type"); ok {
-		d.Set("allowed_request_content_type", v)
+	if _, ok := d.GetOk("allowed_request_content_type_charset"); ok {
+		d.Set("allowed_request_content_type_charset", version.AllowedRequestContentTypeCharset)
 	}
-	if v, ok := d.GetOk("allowed_request_content_type_charset"); ok {
-		d.Set("allowed_request_content_type_charset", v)
+	if _, ok := d.GetOk("arg_length"); ok {
+		d.Set("arg_length", version.ArgLength)
 	}
-	if v, ok := d.GetOk("arg_length"); ok {
-		d.Set("arg_length", v)
+	if _, ok := d.GetOk("arg_name_length"); ok {
+		d.Set("arg_name_length", version.ArgNameLength)
 	}
-	if v, ok := d.GetOk("arg_name_length"); ok {
-		d.Set("arg_name_length", v)
+	if _, ok := d.GetOk("combined_file_sizes"); ok {
+		d.Set("combined_file_sizes", version.CombinedFileSizes)
 	}
-	if v, ok := d.GetOk("combined_file_sizes"); ok {
-		d.Set("combined_file_sizes", v)
+	if _, ok := d.GetOk("critical_anomaly_score"); ok {
+		d.Set("critical_anomaly_score", version.CriticalAnomalyScore)
 	}
-	if v, ok := d.GetOk("critical_anomaly_score"); ok {
-		d.Set("critical_anomaly_score", v)
+	if _, ok := d.GetOk("crs_validate_utf8_encoding"); ok {
+		d.Set("crs_validate_utf8_encoding", version.CRSValidateUTF8Encoding)
 	}
-	if v, ok := d.GetOk("crs_validate_utf8_encoding"); ok {
-		d.Set("crs_validate_utf8_encoding", v)
+	if _, ok := d.GetOk("error_anomaly_score"); ok {
+		d.Set("error_anomaly_score", version.ErrorAnomalyScore)
 	}
-	if v, ok := d.GetOk("error_anomaly_score"); ok {
-		d.Set("error_anomaly_score", v)
+	if _, ok := d.GetOk("high_risk_country_codes"); ok {
+		d.Set("high_risk_country_codes", version.HighRiskCountryCodes)
 	}
-	if v, ok := d.GetOk("high_risk_country_codes"); ok {
-		d.Set("high_risk_country_codes", v)
+	if _, ok := d.GetOk("http_violation_score_threshold"); ok {
+		d.Set("http_violation_score_threshold", version.HTTPViolationScoreThreshold)
 	}
-	if v, ok := d.GetOk("http_violation_score_threshold"); ok {
-		d.Set("http_violation_score_threshold", v)
+	if _, ok := d.GetOk("inbound_anomaly_score_threshold"); ok {
+		d.Set("inbound_anomaly_score_threshold", version.InboundAnomalyScoreThreshold)
 	}
-	if v, ok := d.GetOk("inbound_anomaly_score_threshold"); ok {
-		d.Set("inbound_anomaly_score_threshold", v)
+	if _, ok := d.GetOk("lfi_score_threshold"); ok {
+		d.Set("lfi_score_threshold", version.LFIScoreThreshold)
 	}
-	if v, ok := d.GetOk("lfi_score_threshold"); ok {
-		d.Set("lfi_score_threshold", v)
+	if _, ok := d.GetOk("max_file_size"); ok {
+		d.Set("max_file_size", version.MaxFileSize)
 	}
-	if v, ok := d.GetOk("max_file_size"); ok {
-		d.Set("max_file_size", v)
+	if _, ok := d.GetOk("max_num_args"); ok {
+		d.Set("max_num_args", version.MaxNumArgs)
 	}
-	if v, ok := d.GetOk("max_num_args"); ok {
-		d.Set("max_num_args", v)
+	if _, ok := d.GetOk("notice_anomaly_score"); ok {
+		d.Set("notice_anomaly_score", version.NoticeAnomalyScore)
 	}
-	if v, ok := d.GetOk("notice_anomaly_score"); ok {
-		d.Set("notice_anomaly_score", v)
+	if _, ok := d.GetOk("paranoia_level"); ok {
+		d.Set("paranoia_level", version.ParanoiaLevel)
 	}
-	if v, ok := d.GetOk("paranoia_level"); ok {
-		d.Set("paranoia_level", v)
+	if _, ok := d.GetOk("php_injection_score_threshold"); ok {
+		d.Set("php_injection_score_threshold", version.PHPInjectionScoreThreshold)
 	}
-	if v, ok := d.GetOk("php_injection_score_threshold"); ok {
-		d.Set("php_injection_score_threshold", v)
+	if _, ok := d.GetOk("rce_score_threshold"); ok {
+		d.Set("rce_score_threshold", version.RCEScoreThreshold)
 	}
-	if v, ok := d.GetOk("rce_score_threshold"); ok {
-		d.Set("rce_score_threshold", v)
+	if _, ok := d.GetOk("restricted_extensions"); ok {
+		d.Set("restricted_extensions", version.RestrictedExtensions)
 	}
-	if v, ok := d.GetOk("restricted_extensions"); ok {
-		d.Set("restricted_extensions", v)
+	if _, ok := d.GetOk("restricted_headers"); ok {
+		d.Set("restricted_headers", version.RestrictedHeaders)
 	}
-	if v, ok := d.GetOk("restricted_headers"); ok {
-		d.Set("restricted_headers", v)
+	if _, ok := d.GetOk("rfi_score_threshold"); ok {
+		d.Set("rfi_score_threshold", version.RFIScoreThreshold)
 	}
-	if v, ok := d.GetOk("rfi_score_threshold"); ok {
-		d.Set("rfi_score_threshold", v)
+	if _, ok := d.GetOk("session_fixation_score_threshold"); ok {
+		d.Set("session_fixation_score_threshold", version.SessionFixationScoreThreshold)
 	}
-	if v, ok := d.GetOk("session_fixation_score_threshold"); ok {
-		d.Set("session_fixation_score_threshold", v)
+	if _, ok := d.GetOk("sql_injection_score_threshold"); ok {
+		d.Set("sql_injection_score_threshold", version.SQLInjectionScoreThreshold)
 	}
-	if v, ok := d.GetOk("sql_injection_score_threshold"); ok {
-		d.Set("sql_injection_score_threshold", v)
+	if _, ok := d.GetOk("total_arg_length"); ok {
+		d.Set("total_arg_length", version.TotalArgLength)
 	}
-	if v, ok := d.GetOk("total_arg_length"); ok {
-		d.Set("total_arg_length", v)
+	if _, ok := d.GetOk("warning_anomaly_score"); ok {
+		d.Set("warning_anomaly_score", version.WarningAnomalyScore)
 	}
-	if v, ok := d.GetOk("warning_anomaly_score"); ok {
-		d.Set("warning_anomaly_score", v)
-	}
-	if v, ok := d.GetOk("xss_score_threshold"); ok {
-		d.Set("xss_score_threshold", v)
+	if _, ok := d.GetOk("xss_score_threshold"); ok {
+		d.Set("xss_score_threshold", version.XSSScoreThreshold)
 	}
 }
 

--- a/fastly/resource_fastly_service_waf_configuration_v1.go
+++ b/fastly/resource_fastly_service_waf_configuration_v1.go
@@ -233,7 +233,12 @@ func resourceServiceWAFConfigurationV1Update(d *schema.ResourceData, meta interf
 func resourceServiceWAFConfigurationV1Read(d *schema.ResourceData, meta interface{}) error {
 
 	latestVersion, err := getLatestVersion(d, meta)
-	if err != nil {
+	if errRes, ok := err.(*gofastly.HTTPError); ok {
+		if errRes.StatusCode == 404 {
+			log.Printf("[DEBUG] WAF (%s) was not found - removing from state", d.Get("waf_id").(string))
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/fastly/resource_fastly_service_waf_configuration_v1.go
+++ b/fastly/resource_fastly_service_waf_configuration_v1.go
@@ -69,6 +69,7 @@ func resourceServiceWAFConfigurationV1() *schema.Resource {
 			"crs_validate_utf8_encoding": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Default:     false,
 				Description: "CRS validate UTF8 encoding.",
 			},
 			"error_anomaly_score": {

--- a/fastly/resource_fastly_service_waf_configuration_v1.go
+++ b/fastly/resource_fastly_service_waf_configuration_v1.go
@@ -329,7 +329,7 @@ func buildUpdateInput(d *schema.ResourceData, id string, number int) *gofastly.U
 	}
 }
 
-func refreshWAFConfig(d *schema.ResourceData, version *gofastly.WAFVersion) error {
+func refreshWAFConfig(d *schema.ResourceData, version *gofastly.WAFVersion) {
 
 	pairings := composePairings(version)
 
@@ -350,12 +350,9 @@ func refreshWAFConfig(d *schema.ResourceData, version *gofastly.WAFVersion) erro
 				continue
 			}
 		}
-		if err := d.Set(k, v); err != nil {
-			return err
-		}
+		d.Set(k, v)
 		log.Printf("[DEBUG] GetOk for %v is %v \n", k, ok)
 	}
-	return nil
 }
 
 func composePairings(version *gofastly.WAFVersion) map[string]interface{} {

--- a/fastly/resource_fastly_service_waf_configuration_v1.go
+++ b/fastly/resource_fastly_service_waf_configuration_v1.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"reflect"
 	"sort"
 
 	gofastly "github.com/fastly/go-fastly/fastly"
@@ -68,7 +69,6 @@ func resourceServiceWAFConfigurationV1() *schema.Resource {
 			"crs_validate_utf8_encoding": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
 				Description: "CRS validate UTF8 encoding.",
 			},
 			"error_anomaly_score": {
@@ -294,183 +294,100 @@ func getLatestVersion(d *schema.ResourceData, meta interface{}) (*gofastly.WAFVe
 }
 
 func buildUpdateInput(d *schema.ResourceData, id string, number int) *gofastly.UpdateWAFVersionInput {
-	input := &gofastly.UpdateWAFVersionInput{
-		WAFVersionID:     id,
-		WAFVersionNumber: number,
-		WAFID:            d.Get("waf_id").(string),
+	return &gofastly.UpdateWAFVersionInput{
+		WAFVersionID:                     id,
+		WAFVersionNumber:                 number,
+		WAFID:                            d.Get("waf_id").(string),
+		AllowedHTTPVersions:              d.Get("allowed_http_versions").(string),
+		AllowedMethods:                   d.Get("allowed_methods").(string),
+		AllowedRequestContentType:        d.Get("allowed_request_content_type").(string),
+		AllowedRequestContentTypeCharset: d.Get("allowed_request_content_type_charset").(string),
+		ArgLength:                        d.Get("arg_length").(int),
+		ArgNameLength:                    d.Get("arg_name_length").(int),
+		CombinedFileSizes:                d.Get("combined_file_sizes").(int),
+		CriticalAnomalyScore:             d.Get("critical_anomaly_score").(int),
+		CRSValidateUTF8Encoding:          d.Get("crs_validate_utf8_encoding").(bool),
+		ErrorAnomalyScore:                d.Get("error_anomaly_score").(int),
+		HighRiskCountryCodes:             d.Get("high_risk_country_codes").(string),
+		HTTPViolationScoreThreshold:      d.Get("http_violation_score_threshold").(int),
+		InboundAnomalyScoreThreshold:     d.Get("inbound_anomaly_score_threshold").(int),
+		LFIScoreThreshold:                d.Get("lfi_score_threshold").(int),
+		MaxFileSize:                      d.Get("max_file_size").(int),
+		MaxNumArgs:                       d.Get("max_num_args").(int),
+		NoticeAnomalyScore:               d.Get("notice_anomaly_score").(int),
+		ParanoiaLevel:                    d.Get("paranoia_level").(int),
+		PHPInjectionScoreThreshold:       d.Get("php_injection_score_threshold").(int),
+		RCEScoreThreshold:                d.Get("rce_score_threshold").(int),
+		RestrictedExtensions:             d.Get("restricted_extensions").(string),
+		RestrictedHeaders:                d.Get("restricted_headers").(string),
+		RFIScoreThreshold:                d.Get("rfi_score_threshold").(int),
+		SessionFixationScoreThreshold:    d.Get("session_fixation_score_threshold").(int),
+		SQLInjectionScoreThreshold:       d.Get("sql_injection_score_threshold").(int),
+		TotalArgLength:                   d.Get("total_arg_length").(int),
+		WarningAnomalyScore:              d.Get("warning_anomaly_score").(int),
+		XSSScoreThreshold:                d.Get("xss_score_threshold").(int),
 	}
-	if v, ok := d.GetOk("allowed_http_versions"); ok {
-		input.AllowedHTTPVersions = v.(string)
-	}
-	if v, ok := d.GetOk("allowed_methods"); ok {
-		input.AllowedMethods = v.(string)
-	}
-	if v, ok := d.GetOk("allowed_request_content_type"); ok {
-		input.AllowedRequestContentType = v.(string)
-	}
-	if v, ok := d.GetOk("allowed_request_content_type_charset"); ok {
-		input.AllowedRequestContentTypeCharset = v.(string)
-	}
-	if v, ok := d.GetOk("arg_length"); ok {
-		input.ArgLength = v.(int)
-	}
-	if v, ok := d.GetOk("arg_name_length"); ok {
-		input.ArgNameLength = v.(int)
-	}
-	if v, ok := d.GetOk("combined_file_sizes"); ok {
-		input.CombinedFileSizes = v.(int)
-	}
-	if v, ok := d.GetOk("critical_anomaly_score"); ok {
-		input.CriticalAnomalyScore = v.(int)
-	}
-	if v, ok := d.GetOkExists("crs_validate_utf8_encoding"); ok {
-		input.CRSValidateUTF8Encoding = v.(bool)
-	}
-	if v, ok := d.GetOk("error_anomaly_score"); ok {
-		input.ErrorAnomalyScore = v.(int)
-	}
-	if v, ok := d.GetOk("high_risk_country_codes"); ok {
-		input.HighRiskCountryCodes = v.(string)
-	}
-	if v, ok := d.GetOk("http_violation_score_threshold"); ok {
-		input.HTTPViolationScoreThreshold = v.(int)
-	}
-	if v, ok := d.GetOk("inbound_anomaly_score_threshold"); ok {
-		input.InboundAnomalyScoreThreshold = v.(int)
-	}
-	if v, ok := d.GetOk("lfi_score_threshold"); ok {
-		input.LFIScoreThreshold = v.(int)
-	}
-	if v, ok := d.GetOk("max_file_size"); ok {
-		input.MaxFileSize = v.(int)
-	}
-	if v, ok := d.GetOk("max_num_args"); ok {
-		input.MaxNumArgs = v.(int)
-	}
-	if v, ok := d.GetOk("notice_anomaly_score"); ok {
-		input.NoticeAnomalyScore = v.(int)
-	}
-	if v, ok := d.GetOk("paranoia_level"); ok {
-		input.ParanoiaLevel = v.(int)
-	}
-	if v, ok := d.GetOk("php_injection_score_threshold"); ok {
-		input.PHPInjectionScoreThreshold = v.(int)
-	}
-	if v, ok := d.GetOk("rce_score_threshold"); ok {
-		input.RCEScoreThreshold = v.(int)
-	}
-	if v, ok := d.GetOk("restricted_extensions"); ok {
-		input.RestrictedExtensions = v.(string)
-	}
-	if v, ok := d.GetOk("restricted_headers"); ok {
-		input.RestrictedHeaders = v.(string)
-	}
-	if v, ok := d.GetOk("rfi_score_threshold"); ok {
-		input.RFIScoreThreshold = v.(int)
-	}
-	if v, ok := d.GetOk("session_fixation_score_threshold"); ok {
-		input.SessionFixationScoreThreshold = v.(int)
-	}
-	if v, ok := d.GetOk("sql_injection_score_threshold"); ok {
-		input.SQLInjectionScoreThreshold = v.(int)
-	}
-	if v, ok := d.GetOk("total_arg_length"); ok {
-		input.TotalArgLength = v.(int)
-	}
-	if v, ok := d.GetOk("warning_anomaly_score"); ok {
-		input.WarningAnomalyScore = v.(int)
-	}
-	if v, ok := d.GetOk("xss_score_threshold"); ok {
-		input.XSSScoreThreshold = v.(int)
-	}
-	return input
 }
 
-func refreshWAFConfig(d *schema.ResourceData, version *gofastly.WAFVersion) {
+func refreshWAFConfig(d *schema.ResourceData, version *gofastly.WAFVersion) error {
 
-	if _, ok := d.GetOk("allowed_http_versions"); ok {
-		d.Set("allowed_http_versions", version.AllowedHTTPVersions)
+	pairings := composePairings(version)
+
+	d.SetId(version.ID)
+	for k, v := range pairings {
+		var ok bool
+		switch t := reflect.TypeOf(v).String(); t {
+		case "string":
+			if _, ok := d.GetOk(k); !ok || v.(string) == "" {
+				continue
+			}
+		case "int":
+			if _, ok := d.GetOk(k); !ok || v.(int) == 0 {
+				continue
+			}
+		case "bool":
+			if _, ok := d.GetOkExists(k); !ok {
+				continue
+			}
+		}
+		if err := d.Set(k, v); err != nil {
+			return err
+		}
+		log.Printf("[DEBUG] GetOk for %v is %v \n", k, ok)
 	}
-	if _, ok := d.GetOk("allowed_methods"); ok {
-		d.Set("allowed_methods", version.AllowedMethods)
-	}
-	if _, ok := d.GetOk("allowed_request_content_type"); ok {
-		d.Set("allowed_request_content_type", version.AllowedRequestContentType)
-	}
-	if _, ok := d.GetOk("allowed_request_content_type_charset"); ok {
-		d.Set("allowed_request_content_type_charset", version.AllowedRequestContentTypeCharset)
-	}
-	if _, ok := d.GetOk("arg_length"); ok {
-		d.Set("arg_length", version.ArgLength)
-	}
-	if _, ok := d.GetOk("arg_name_length"); ok {
-		d.Set("arg_name_length", version.ArgNameLength)
-	}
-	if _, ok := d.GetOk("combined_file_sizes"); ok {
-		d.Set("combined_file_sizes", version.CombinedFileSizes)
-	}
-	if _, ok := d.GetOk("critical_anomaly_score"); ok {
-		d.Set("critical_anomaly_score", version.CriticalAnomalyScore)
-	}
-	if _, ok := d.GetOk("crs_validate_utf8_encoding"); ok {
-		d.Set("crs_validate_utf8_encoding", version.CRSValidateUTF8Encoding)
-	}
-	if _, ok := d.GetOk("error_anomaly_score"); ok {
-		d.Set("error_anomaly_score", version.ErrorAnomalyScore)
-	}
-	if _, ok := d.GetOk("high_risk_country_codes"); ok {
-		d.Set("high_risk_country_codes", version.HighRiskCountryCodes)
-	}
-	if _, ok := d.GetOk("http_violation_score_threshold"); ok {
-		d.Set("http_violation_score_threshold", version.HTTPViolationScoreThreshold)
-	}
-	if _, ok := d.GetOk("inbound_anomaly_score_threshold"); ok {
-		d.Set("inbound_anomaly_score_threshold", version.InboundAnomalyScoreThreshold)
-	}
-	if _, ok := d.GetOk("lfi_score_threshold"); ok {
-		d.Set("lfi_score_threshold", version.LFIScoreThreshold)
-	}
-	if _, ok := d.GetOk("max_file_size"); ok {
-		d.Set("max_file_size", version.MaxFileSize)
-	}
-	if _, ok := d.GetOk("max_num_args"); ok {
-		d.Set("max_num_args", version.MaxNumArgs)
-	}
-	if _, ok := d.GetOk("notice_anomaly_score"); ok {
-		d.Set("notice_anomaly_score", version.NoticeAnomalyScore)
-	}
-	if _, ok := d.GetOk("paranoia_level"); ok {
-		d.Set("paranoia_level", version.ParanoiaLevel)
-	}
-	if _, ok := d.GetOk("php_injection_score_threshold"); ok {
-		d.Set("php_injection_score_threshold", version.PHPInjectionScoreThreshold)
-	}
-	if _, ok := d.GetOk("rce_score_threshold"); ok {
-		d.Set("rce_score_threshold", version.RCEScoreThreshold)
-	}
-	if _, ok := d.GetOk("restricted_extensions"); ok {
-		d.Set("restricted_extensions", version.RestrictedExtensions)
-	}
-	if _, ok := d.GetOk("restricted_headers"); ok {
-		d.Set("restricted_headers", version.RestrictedHeaders)
-	}
-	if _, ok := d.GetOk("rfi_score_threshold"); ok {
-		d.Set("rfi_score_threshold", version.RFIScoreThreshold)
-	}
-	if _, ok := d.GetOk("session_fixation_score_threshold"); ok {
-		d.Set("session_fixation_score_threshold", version.SessionFixationScoreThreshold)
-	}
-	if _, ok := d.GetOk("sql_injection_score_threshold"); ok {
-		d.Set("sql_injection_score_threshold", version.SQLInjectionScoreThreshold)
-	}
-	if _, ok := d.GetOk("total_arg_length"); ok {
-		d.Set("total_arg_length", version.TotalArgLength)
-	}
-	if _, ok := d.GetOk("warning_anomaly_score"); ok {
-		d.Set("warning_anomaly_score", version.WarningAnomalyScore)
-	}
-	if _, ok := d.GetOk("xss_score_threshold"); ok {
-		d.Set("xss_score_threshold", version.XSSScoreThreshold)
+	return nil
+}
+
+func composePairings(version *gofastly.WAFVersion) map[string]interface{} {
+	return map[string]interface{}{
+		"allowed_http_versions":                version.AllowedHTTPVersions,
+		"allowed_methods":                      version.AllowedMethods,
+		"allowed_request_content_type":         version.AllowedRequestContentType,
+		"allowed_request_content_type_charset": version.AllowedRequestContentTypeCharset,
+		"arg_length":                           version.ArgLength,
+		"arg_name_length":                      version.ArgNameLength,
+		"combined_file_sizes":                  version.CombinedFileSizes,
+		"critical_anomaly_score":               version.CriticalAnomalyScore,
+		"crs_validate_utf8_encoding":           version.CRSValidateUTF8Encoding,
+		"error_anomaly_score":                  version.ErrorAnomalyScore,
+		"high_risk_country_codes":              version.HighRiskCountryCodes,
+		"http_violation_score_threshold":       version.HTTPViolationScoreThreshold,
+		"inbound_anomaly_score_threshold":      version.InboundAnomalyScoreThreshold,
+		"lfi_score_threshold":                  version.LFIScoreThreshold,
+		"max_file_size":                        version.MaxFileSize,
+		"max_num_args":                         version.MaxNumArgs,
+		"notice_anomaly_score":                 version.NoticeAnomalyScore,
+		"paranoia_level":                       version.ParanoiaLevel,
+		"php_injection_score_threshold":        version.PHPInjectionScoreThreshold,
+		"rce_score_threshold":                  version.RCEScoreThreshold,
+		"restricted_extensions":                version.RestrictedExtensions,
+		"restricted_headers":                   version.RestrictedHeaders,
+		"rfi_score_threshold":                  version.RFIScoreThreshold,
+		"session_fixation_score_threshold":     version.SessionFixationScoreThreshold,
+		"sql_injection_score_threshold":        version.SQLInjectionScoreThreshold,
+		"total_arg_length":                     version.TotalArgLength,
+		"warning_anomaly_score":                version.WarningAnomalyScore,
+		"xss_score_threshold":                  version.XSSScoreThreshold,
 	}
 }
 

--- a/fastly/resource_fastly_service_waf_configuration_v1_test.go
+++ b/fastly/resource_fastly_service_waf_configuration_v1_test.go
@@ -64,6 +64,8 @@ func TestAccFastlyServiceWAFVersionV1DetermineVersion(t *testing.T) {
 }
 
 func TestAccFastlyServiceWAFVersionV1Add(t *testing.T) {
+	t.Parallel()
+
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
@@ -86,6 +88,8 @@ func TestAccFastlyServiceWAFVersionV1Add(t *testing.T) {
 }
 
 func TestAccFastlyServiceWAFVersionV1AddExistingService(t *testing.T) {
+	t.Parallel()
+
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
@@ -114,6 +118,8 @@ func TestAccFastlyServiceWAFVersionV1AddExistingService(t *testing.T) {
 }
 
 func TestAccFastlyServiceWAFVersionV1Update(t *testing.T) {
+	t.Parallel()
+
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -147,6 +153,8 @@ func TestAccFastlyServiceWAFVersionV1Update(t *testing.T) {
 }
 
 func TestAccFastlyServiceWAFVersionV1Delete(t *testing.T) {
+	t.Parallel()
+
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)

--- a/fastly/resource_fastly_service_waf_configuration_v1_test.go
+++ b/fastly/resource_fastly_service_waf_configuration_v1_test.go
@@ -64,14 +64,12 @@ func TestAccFastlyServiceWAFVersionV1DetermineVersion(t *testing.T) {
 }
 
 func TestAccFastlyServiceWAFVersionV1Add(t *testing.T) {
-	t.Parallel()
-
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
 	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -88,14 +86,12 @@ func TestAccFastlyServiceWAFVersionV1Add(t *testing.T) {
 }
 
 func TestAccFastlyServiceWAFVersionV1AddExistingService(t *testing.T) {
-	t.Parallel()
-
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
 	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -118,8 +114,6 @@ func TestAccFastlyServiceWAFVersionV1AddExistingService(t *testing.T) {
 }
 
 func TestAccFastlyServiceWAFVersionV1Update(t *testing.T) {
-	t.Parallel()
-
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -129,7 +123,7 @@ func TestAccFastlyServiceWAFVersionV1Update(t *testing.T) {
 	wafVerInput2 := testAccFastlyServiceWAFVersionV1BuildConfig(22)
 	wafVer2 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput2, "")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -153,14 +147,12 @@ func TestAccFastlyServiceWAFVersionV1Update(t *testing.T) {
 }
 
 func TestAccFastlyServiceWAFVersionV1Delete(t *testing.T) {
-	t.Parallel()
-
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
 	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,


### PR DESCRIPTION
This PR contains a few small changes to better comply with terraform provider conventions:
- adding and consolidating logging entries
- delete resource function should unset ID
- read resource function should unset ID if not found

it also makes WAF related acceptance tests run in parallel, but we need to check with Fastly if this could cause any issues 