### PR TITLE
Waf documentation

### DIFF
--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -6,14 +6,11 @@ description: |-
   Get information on Fastly WAF rules.
 ---
 
--> **Note:** This page is about v1.1.0 and later of the Fastly terraform provider.
+-> **Note:** This data source is only available from x.x.x of the Fastly terraform provider.
 
 # fastly_waf_rules
 
 Use this data source to get the [WAF rules][1] of Fastly.
-
-~> **Warning:** The data source's filters are applied using an **AND** boolean operator, so depending on the combination of those, 
-they may become mutually exclusive.
 
 ## Example Usage
 
@@ -51,6 +48,9 @@ data "fastly_waf_rules" "all" {
 ```
 
 ## Argument Reference
+
+~> **Warning:** The data source's filters are applied using an **AND** boolean operator, so depending on the combination of those, 
+they may become mutually exclusive.
 
 * `publishers` - Inclusion filter by WAF rule's publishers.
 * `tags` - Inclusion filter by WAF rule's tags.

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -47,6 +47,82 @@ data "fastly_waf_rules" "all" {
 }
 ```
 
+Usage with WAF configuration resource:
+
+```hcl
+variable "type_status" {
+  type = map(string)
+  default = {
+    score     = "score"
+    threshold = "log"
+    strict    = "log"
+  }
+}
+
+resource "fastly_service_v1" "demo" {
+  name = "demofastly"
+
+  domain {
+    name    = "demo.notexample.com"
+    comment = "demo"
+  }
+
+  backend {
+    address = "127.0.0.1"
+    name    = "origin1"
+    port    = 80
+  }
+
+  condition {
+    name      = "Waf_Prefetch"
+    type      = "PREFETCH"
+    statement = "req.backend.is_origin"
+  }
+
+  # this condition will always be false
+  # adding it to the response object created below
+  # prevents Fastly from returning a 403 on all of your traffic
+  condition {
+    name      = "WAF_always_false"
+    statement = "false"
+    type      = "REQUEST"
+  }
+
+  response_object {
+    name     = "WAF_Response"
+    status   = "403"
+    response = "Forbidden"
+    content  = "content"
+    request_condition = "WAF_always_false"
+  }
+
+  waf {
+    prefetch_condition = "Waf_Prefetch"
+    response_object    = "WAF_Response"
+  }
+
+  force_destroy = true
+}
+
+data "fastly_waf_rules" "owasp" {
+  publishers = ["owasp"]
+}
+
+resource "fastly_service_waf_configuration_v1" "waf" {
+  waf_id                          = fastly_service_v1.demo.waf[0].waf_id
+  http_violation_score_threshold  = 100
+
+  dynamic "rule" {
+    for_each = data.fastly_waf_rules.owasp.rules
+    content {
+      modsec_rule_id = rule.value.modsec_rule_id
+      revision       = rule.value.latest_revision_number
+      status         = lookup(var.type_status, rule.value.type, "log")
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 ~> **Warning:** The data source's filters are applied using an **AND** boolean operator, so depending on the combination of those, 

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -66,4 +66,4 @@ The `rules` block supports:
 * `latest_revision_number` - The rule's latest revision.
 * `type` - The rule's type.
 
-[1]: https://docs.fastly.com/en/guides/fastly-waf-rule-set-updates-maintenance
+[1]: https://docs.fastly.com/api/ngwaf#ngwaf_rules

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -44,7 +44,7 @@ Usage without filters:
 
 ```hcl
 data "fastly_waf_rules" "all" {
-  // This will retrieve the entire rule list available on the server at the time.
+  // This will retrieve the entire list of rules available from the API at the time.
 }
 ```
 

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -94,7 +94,7 @@ resource "fastly_service_v1" "demo" {
     status            = "403"
     response          = "Forbidden"
     content_type      = "text/html"
-    content           = "<html><body>something</body></html>"
+    content           = "<html><body>Forbidden</body></html>"
     request_condition = "WAF_always_false"
   }
 

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -127,8 +127,7 @@ resource "fastly_service_waf_configuration_v1" "waf" {
 
 ## Argument Reference
 
-~> **Warning:** The data source's filters are applied using an **AND** boolean operator, so depending on the combination of filters, 
-they may become mutually exclusive.
+~> **Warning:** The data source's filters are applied using an **AND** boolean operator, so depending on the combination of filters, they may become mutually exclusive.
 
 * `publishers` - Inclusion filter by WAF rule's publishers.
 * `tags` - Inclusion filter by WAF rule's tags.

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -12,6 +12,9 @@ description: |-
 
 Use this data source to get the [WAF rules][1] of Fastly.
 
+~> **Warning:** The data source's filters are applied using an **AND** boolean operator, so depending on the combination of those, 
+they may become mutually exclusive.
+
 ## Example Usage
 
 Usage with publishers Filter:
@@ -36,6 +39,14 @@ Usage with exclude filter:
 data "fastly_waf_rules" "owasp_with_exclusions" {
   publishers = ["owasp"]
   exclude_modsec_rule_ids = [1010090]
+}
+```
+
+Usage without filters:
+
+```hcl
+data "fastly_waf_rules" "all" {
+  // This will retrieve the entire rule list available on the server at the time.
 }
 ```
 

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -13,50 +13,14 @@ Use this data source to get the [WAF rules][1] of Fastly.
 ## Simple Example Usage
 
 ```hcl
-variable "type_status" {
-  type = map(string)
-  default = {
-    score     = "score"
-    threshold = "log"
-    strict    = "log"
-  }
-}
 
-source "fastly_service_v1" "myservice" {
-  name = "demofastly"
-  domain {
-    name    = "demo.notexample.com"
-    comment = "demo"
-  }
-  backend {
-    address = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
-    name    = "AWS S3 hosting"
-    port    = 80
-  }
-  condition {
-    name      = "WAF_Prefetch"
-    type      = "PREFETCH"
-    statement = "req.url~+\"index.html\""
-  }
-  response_object {
-    name     = "WAF_Response"
-    status   = "403"
-    response = "Forbidden"
-    content  = "content2"
-  }
-  waf {
-    prefetch_condition = "WAF_Prefetch"
-    response_object    = "WAF_Response"
-  }
-  force_destroy = true
-}
 
 data "fastly_waf_rules" "owasp" {
   publishers = ["owasp"]
 }
 
 resource "fastly_service_waf_configuration_v1" "waf" {
-  waf_id                          = fastly_service_v1.foo.waf[0].waf_id
+  waf_id                          = fastly_service_v1.demo.waf[0].waf_id
   http_violation_score_threshold  = 202
 
   dynamic "rule" {

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -1,0 +1,146 @@
+---
+layout: "fastly"
+page_title: "Fastly: fastly_waf_rules"
+sidebar_current: "docs-fastly-datasource-waf_rules"
+description: |-
+  Get information on Fastly WAF rules.
+---
+
+# fastly_waf_rules
+
+Use this data source to get the [WAF rules][1] of Fastly.
+
+## Simple Example Usage
+
+```hcl
+variable "type_status" {
+  type = map(string)
+  default = {
+    score     = "score"
+    threshold = "log"
+    strict    = "log"
+  }
+}
+
+source "fastly_service_v1" "myservice" {
+  name = "demofastly"
+  domain {
+    name    = "demo.notexample.com"
+    comment = "demo"
+  }
+  backend {
+    address = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
+    name    = "AWS S3 hosting"
+    port    = 80
+  }
+  condition {
+    name      = "WAF_Prefetch"
+    type      = "PREFETCH"
+    statement = "req.url~+\"index.html\""
+  }
+  response_object {
+    name     = "WAF_Response"
+    status   = "403"
+    response = "Forbidden"
+    content  = "content2"
+  }
+  waf {
+    prefetch_condition = "WAF_Prefetch"
+    response_object    = "WAF_Response"
+  }
+  force_destroy = true
+}
+
+data "fastly_waf_rules" "owasp" {
+  publishers = ["owasp"]
+}
+
+resource "fastly_service_waf_configuration_v1" "waf" {
+  waf_id                          = fastly_service_v1.foo.waf[0].waf_id
+  http_violation_score_threshold  = 202
+
+  dynamic "rule" {
+    for_each = data.fastly_waf_rules.owasp.rules
+    content {
+      modsec_rule_id = rule.value.modsec_rule_id
+      revision       = rule.value.latest_revision_number
+      status         = lookup(var.type_status, rule.value.type, "log")
+    }
+  }
+}
+```
+
+## Example Usage by ModSecurity ID
+
+```hcl
+variable "type_status" {
+  type = map(string)
+  default = {
+    score     = "score"
+    threshold = "log"
+    strict    = "log"
+  }
+}
+
+variable "individual_rules" {
+  type = map(string)
+  default = {
+    1010020 = "block"
+  }
+}
+
+source "fastly_service_v1" "myservice" {
+  name = "demofastly"
+  domain {
+    name    = "demo.notexample.com"
+    comment = "demo"
+  }
+  backend {
+    address = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
+    name    = "AWS S3 hosting"
+    port    = 80
+  }
+  condition {
+    name      = "WAF_Prefetch"
+    type      = "PREFETCH"
+    statement = "req.url~+\"index.html\""
+  }
+  response_object {
+    name     = "WAF_Response"
+    status   = "403"
+    response = "Forbidden"
+    content  = "content2"
+  }
+  waf {
+    prefetch_condition = "WAF_Prefetch"
+    response_object    = "WAF_Response"
+  }
+  force_destroy = true
+}
+
+data "fastly_waf_rules" "owasp" {
+  publishers = ["owasp"]
+}
+
+resource "fastly_service_waf_configuration_v1" "waf" {
+  waf_id                          = fastly_service_v1.foo.waf[0].waf_id
+  http_violation_score_threshold  = 202
+
+  dynamic "rule" {
+    for_each = data.fastly_waf_rules.owasp.rules
+    content {
+      modsec_rule_id = rule.value.modsec_rule_id
+      revision       = rule.value.latest_revision_number
+      status         = lookup(var.individual_rules, rule.value.modsec_rule_id, lookup(var.type_status, rule.value.type, "log"))
+    }
+  }
+}
+```
+
+## Attributes Reference
+
+* `publishers` - Inclusion filter by WAF rule publishers.
+* `tags` - Inclusion filter by WAF rules tags.
+* `exclude_modsec_rule_ids` - Exclusion filter by WAF rule ModSecurity ID.
+
+[1]: https://docs.fastly.com/guides/securing-communications/accessing-fastlys-ip-ranges

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -75,7 +75,7 @@ resource "fastly_service_v1" "demo" {
   }
 
   condition {
-    name      = "Waf_Prefetch"
+    name      = "WAF_Prefetch"
     type      = "PREFETCH"
     statement = "req.backend.is_origin"
   }
@@ -90,15 +90,16 @@ resource "fastly_service_v1" "demo" {
   }
 
   response_object {
-    name     = "WAF_Response"
-    status   = "403"
-    response = "Forbidden"
-    content  = "content"
+    name              = "WAF_Response"
+    status            = "403"
+    response          = "Forbidden"
+    content_type      = "text/html"
+    content           = "<html><body>something</body></html>"
     request_condition = "WAF_always_false"
   }
 
   waf {
-    prefetch_condition = "Waf_Prefetch"
+    prefetch_condition = "WAF_Prefetch"
     response_object    = "WAF_Response"
   }
 

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -82,7 +82,7 @@ resource "fastly_service_v1" "demo" {
 
   # This condition will always be false
   # adding it to the response object created below
-  # prevents Fastly from returning a 403 on all of your traffic
+  # prevents Fastly from returning a 403 on all of your traffic.
   condition {
     name      = "WAF_always_false"
     statement = "false"

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -64,7 +64,7 @@ resource "fastly_service_v1" "demo" {
   name = "demofastly"
 
   domain {
-    name    = "demo.notexample.com"
+    name    = "example.com"
     comment = "demo"
   }
 

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -58,7 +58,7 @@ they may become mutually exclusive.
 
 ## Attribute Reference
 
-* `rules` - The Web Application Firewall's active rules.
+* `rules` - The Web Application Firewall's rules result set.
 
 The `rules` block supports:
 

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -6,105 +6,53 @@ description: |-
   Get information on Fastly WAF rules.
 ---
 
+-> **Note:** This page is about v1.1.0 and later of the Fastly terraform provider.
+
 # fastly_waf_rules
 
 Use this data source to get the [WAF rules][1] of Fastly.
 
-## Simple Example Usage
+## Example Usage
+
+Usage with publishers Filter:
 
 ```hcl
-
-
 data "fastly_waf_rules" "owasp" {
   publishers = ["owasp"]
 }
-
-resource "fastly_service_waf_configuration_v1" "waf" {
-  waf_id                          = fastly_service_v1.demo.waf[0].waf_id
-  http_violation_score_threshold  = 202
-
-  dynamic "rule" {
-    for_each = data.fastly_waf_rules.owasp.rules
-    content {
-      modsec_rule_id = rule.value.modsec_rule_id
-      revision       = rule.value.latest_revision_number
-      status         = lookup(var.type_status, rule.value.type, "log")
-    }
-  }
-}
 ```
 
-## Example Usage by ModSecurity ID
+Usage with tags filter:
 
 ```hcl
-variable "type_status" {
-  type = map(string)
-  default = {
-    score     = "score"
-    threshold = "log"
-    strict    = "log"
-  }
-}
-
-variable "individual_rules" {
-  type = map(string)
-  default = {
-    1010020 = "block"
-  }
-}
-
-source "fastly_service_v1" "myservice" {
-  name = "demofastly"
-  domain {
-    name    = "demo.notexample.com"
-    comment = "demo"
-  }
-  backend {
-    address = "demo.notexample.com.s3-website-us-west-2.amazonaws.com"
-    name    = "AWS S3 hosting"
-    port    = 80
-  }
-  condition {
-    name      = "WAF_Prefetch"
-    type      = "PREFETCH"
-    statement = "req.url~+\"index.html\""
-  }
-  response_object {
-    name     = "WAF_Response"
-    status   = "403"
-    response = "Forbidden"
-    content  = "content2"
-  }
-  waf {
-    prefetch_condition = "WAF_Prefetch"
-    response_object    = "WAF_Response"
-  }
-  force_destroy = true
-}
-
-data "fastly_waf_rules" "owasp" {
-  publishers = ["owasp"]
-}
-
-resource "fastly_service_waf_configuration_v1" "waf" {
-  waf_id                          = fastly_service_v1.foo.waf[0].waf_id
-  http_violation_score_threshold  = 202
-
-  dynamic "rule" {
-    for_each = data.fastly_waf_rules.owasp.rules
-    content {
-      modsec_rule_id = rule.value.modsec_rule_id
-      revision       = rule.value.latest_revision_number
-      status         = lookup(var.individual_rules, rule.value.modsec_rule_id, lookup(var.type_status, rule.value.type, "log"))
-    }
-  }
+data "fastly_waf_rules" "tag" {
+  tags = ["language-html", "language-jsp"]
 }
 ```
 
-## Attributes Reference
+Usage with exclude filter:
 
-* `publishers` - Inclusion filter by WAF rule publishers.
-* `tags` - Inclusion filter by WAF rules tags.
-* `exclude_modsec_rule_ids` - Exclusion filter by WAF rule ModSecurity ID.
+```hcl
+data "fastly_waf_rules" "owasp_with_exclusions" {
+  publishers = ["owasp"]
+  exclude_modsec_rule_ids = [1010090]
+}
+```
 
-[1]: https://docs.fastly.com/guides/securing-communications/accessing-fastlys-ip-ranges
+## Argument Reference
+
+* `publishers` - Inclusion filter by WAF rule's publishers.
+* `tags` - Inclusion filter by WAF rule's tags.
+* `exclude_modsec_rule_ids` - Exclusion filter by WAF rule's ModSecurity ID.
+
+## Attribute Reference
+
+* `rules` - The Web Application Firewall's active rules.
+
+The `rules` block supports:
+
+* `modsec_rule_id` - The rule's modsecurity ID.
+* `latest_revision_number` - The rule's latest revision.
+* `type` - The rule's type.
+
+[1]: https://docs.fastly.com/en/guides/fastly-waf-rule-set-updates-maintenance

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -127,7 +127,7 @@ resource "fastly_service_waf_configuration_v1" "waf" {
 
 ## Argument Reference
 
-~> **Warning:** The data source's filters are applied using an **AND** boolean operator, so depending on the combination of those, 
+~> **Warning:** The data source's filters are applied using an **AND** boolean operator, so depending on the combination of filters, 
 they may become mutually exclusive.
 
 * `publishers` - Inclusion filter by WAF rule's publishers.

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -11,7 +11,7 @@ description: |-
 # fastly_waf_rules
 
 Use this data source to get the [WAF rules][1] of Fastly. A set of third-party rules from the OWASP Core Ruleset, commercial sources, and open source, in addition to Fastly-generated rules.
-They offer protection from injection attacks and cross site scripting amongst other key application-layer attacks
+They offer protection from injection attacks and cross site scripting amongst other key application-layer attacks.
 
 ## Example Usage
 

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -80,7 +80,7 @@ resource "fastly_service_v1" "demo" {
     statement = "req.backend.is_origin"
   }
 
-  # this condition will always be false
+  # This condition will always be false
   # adding it to the response object created below
   # prevents Fastly from returning a 403 on all of your traffic
   condition {

--- a/website/docs/d/waf_rules.html.markdown
+++ b/website/docs/d/waf_rules.html.markdown
@@ -10,7 +10,8 @@ description: |-
 
 # fastly_waf_rules
 
-Use this data source to get the [WAF rules][1] of Fastly.
+Use this data source to get the [WAF rules][1] of Fastly. A set of third-party rules from the OWASP Core Ruleset, commercial sources, and open source, in addition to Fastly-generated rules.
+They offer protection from injection attacks and cross site scripting amongst other key application-layer attacks
 
 ## Example Usage
 

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -153,7 +153,7 @@ resource "fastly_service_v1" "demo" {
 }
 ```
 
--> **Note:** The following example is about v1.1.0 and later of the Fastly terraform provider.
+-> **Note:** The following example is only available from x.x.x of the Fastly terraform provider.
 
 Basic usage with [Web Application Firewall](https://docs.fastly.com/en/guides/web-application-firewall):
 

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -153,6 +153,45 @@ resource "fastly_service_v1" "demo" {
 }
 ```
 
+Basic usage with [Web Application Firewall](https://docs.fastly.com/api/config#director):
+
+```hcl
+resource "fastly_service_v1" "demo" {
+  name = "demofastly"
+
+  domain {
+    name    = "demo.notexample.com"
+    comment = "demo"
+  }
+
+  backend {
+    address = "127.0.0.1"
+    name    = "origin1"
+    port    = 80
+  }
+
+  condition {
+    name      = "Waf_Prefetch"
+    type      = "PREFETCH"
+    statement = "req.url~+\"index.html\""
+  }
+
+  response_object {
+    name     = "WAF_Response"
+    status   = "403"
+    response = "Forbidden"
+    content  = "content2"
+  }
+
+  waf {
+    prefetch_condition = "Waf_Prefetch"
+    response_object    = "WAF_Response"
+  }
+
+  force_destroy = true
+}
+```
+
 -> **Note:** For an AWS S3 Bucket, the Backend address is
 `<domain>.s3-website-<region>.amazonaws.com`. The `default_host` attribute
 should be set to `<bucket_name>.s3-website-<region>.amazonaws.com`. See the
@@ -534,6 +573,11 @@ via API. Default is `false`. It is important to note that changing this attribut
 dictionary, discard the current items in the dictionary. Using a write-only/private dictionary should only be done if
 the items are managed outside of Terraform.
 
+The `waf` block supports:
+
+* `response_object` - (Required) A Web Application Firewall's (WAF) response object
+* `prefetch_condition` - (Required) A Web Application Firewall's (WAF) prefetch condition
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following attributes are exported:
@@ -553,6 +597,10 @@ The `acl` block exports:
 The `dictionary` block exports:
 
 * `dictionary_id` - The ID of the dictionary.
+
+The `waf` block exports:
+
+* `waf_id` - The ID of the waf.
 
 [fastly-s3]: https://docs.fastly.com/guides/integrations/amazon-s3
 [fastly-cname]: https://docs.fastly.com/guides/basic-setup/adding-cname-records

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -192,7 +192,7 @@ resource "fastly_service_v1" "demo" {
     status            = "403"
     response          = "Forbidden"
     content_type      = "text/html"
-    content           = "<html><body>something</body></html>"
+    content           = "<html><body>Forbidden</body></html>"
     request_condition = "WAF_always_false"
   }
 

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -162,7 +162,7 @@ resource "fastly_service_v1" "demo" {
   name = "demofastly"
 
   domain {
-    name    = "demo.notexample.com"
+    name    = "example.com"
     comment = "demo"
   }
 

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -580,7 +580,7 @@ The `waf` block supports:
 * `response_object` - (Required) A Web Application Firewall's (WAF) response object.
 * `prefetch_condition` - (Required) Name of already defined `condition` to apply. This `condition` must be of type `PREFETCH`. 
 For detailed information about Conditionals, see [Fastly's Documentation on Conditionals][fastly-conditionals].
-* `disabled` - (Optional) The means to disable the WAF. Disabling a WAF removes all rules and restore all configuration 
+* `disabled` - (Optional) This flag disables the WAF. Disabling a WAF removes all rules and restore all configuration 
 to its default values. 
 
 ## Attributes Reference

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -178,7 +178,7 @@ resource "fastly_service_v1" "demo" {
     statement = "req.backend.is_origin"
   }
 
-  # this condition will always be false
+  # This condition will always be false
   # adding it to the response object created below
   # prevents Fastly from returning a 403 on all of your traffic
   condition {

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -188,10 +188,11 @@ resource "fastly_service_v1" "demo" {
   }
 
   response_object {
-    name     = "WAF_Response"
-    status   = "403"
-    response = "Forbidden"
-    content  = "content"
+    name              = "WAF_Response"
+    status            = "403"
+    response          = "Forbidden"
+    content_type      = "text/html"
+    content           = "<html><body>something</body></html>"
     request_condition = "WAF_always_false"
   }
 
@@ -587,7 +588,7 @@ the items are managed outside of Terraform.
 
 The `waf` block supports:
 
-* `response_object` - (Required) A Web Application Firewall's (WAF) response object.
+* `response_object` - (Required) The response object used by the Web Application Firewall.
 * `prefetch_condition` - (Required) Name of already defined `condition` to apply. This `condition` must be of type `PREFETCH`. 
 For detailed information about Conditionals, see [Fastly's Documentation on Conditionals][fastly-conditionals].
 * `disabled` - (Optional) This flag disables the WAF. When a WAF is disabled, all configuration remains but in a inactive state. 

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -153,7 +153,9 @@ resource "fastly_service_v1" "demo" {
 }
 ```
 
-Basic usage with [Web Application Firewall](https://docs.fastly.com/api/config#director):
+-> **Note:** The following example is about v1.1.0 and later of the Fastly terraform provider.
+
+Basic usage with [Web Application Firewall](https://docs.fastly.com/en/guides/web-application-firewall):
 
 ```hcl
 resource "fastly_service_v1" "demo" {
@@ -575,8 +577,11 @@ the items are managed outside of Terraform.
 
 The `waf` block supports:
 
-* `response_object` - (Required) A Web Application Firewall's (WAF) response object
-* `prefetch_condition` - (Required) A Web Application Firewall's (WAF) prefetch condition
+* `response_object` - (Required) A Web Application Firewall's (WAF) response object.
+* `prefetch_condition` - (Required) Name of already defined `condition` to apply. This `condition` must be of type `PREFETCH`. 
+For detailed information about Conditionals, see [Fastly's Documentation on Conditionals][fastly-conditionals].
+* `disabled` - (Optional) The means to disable the WAF. Disabling a WAF removes all rules and restore all configuration 
+to its default values. 
 
 ## Attributes Reference
 
@@ -600,7 +605,7 @@ The `dictionary` block exports:
 
 The `waf` block exports:
 
-* `waf_id` - The ID of the waf.
+* `waf_id` - The ID of the WAF.
 
 [fastly-s3]: https://docs.fastly.com/guides/integrations/amazon-s3
 [fastly-cname]: https://docs.fastly.com/guides/basic-setup/adding-cname-records

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -175,7 +175,16 @@ resource "fastly_service_v1" "demo" {
   condition {
     name      = "WAF_Prefetch"
     type      = "PREFETCH"
-    statement = "req.url~+\"index.html\""
+    statement = "req.backend.is_origin"
+  }
+
+  # this condition will always be false
+  # adding it to the response object created below
+  # prevents Fastly from returning a 403 on all of your traffic
+  condition {
+    name      = "WAF_always_false"
+    statement = "false"
+    type      = "REQUEST"
   }
 
   response_object {
@@ -183,6 +192,7 @@ resource "fastly_service_v1" "demo" {
     status   = "403"
     response = "Forbidden"
     content  = "content"
+    request_condition = "WAF_always_false"
   }
 
   waf {

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -588,7 +588,7 @@ the items are managed outside of Terraform.
 
 The `waf` block supports:
 
-* `response_object` - (Required) The response object used by the Web Application Firewall.
+* `response_object` - (Required) The name of the [response object](#response_object) used by the Web Application Firewall.
 * `prefetch_condition` - (Required) Name of already defined `condition` to apply. This `condition` must be of type `PREFETCH`. 
 For detailed information about Conditionals, see [Fastly's Documentation on Conditionals][fastly-conditionals].
 * `disabled` - (Optional) This flag disables the WAF. When a WAF is disabled, all configuration remains but in a inactive state. 

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -171,7 +171,7 @@ resource "fastly_service_v1" "demo" {
   }
 
   condition {
-    name      = "Waf_Prefetch"
+    name      = "WAF_Prefetch"
     type      = "PREFETCH"
     statement = "req.url~+\"index.html\""
   }
@@ -180,11 +180,11 @@ resource "fastly_service_v1" "demo" {
     name     = "WAF_Response"
     status   = "403"
     response = "Forbidden"
-    content  = "content2"
+    content  = "content"
   }
 
   waf {
-    prefetch_condition = "Waf_Prefetch"
+    prefetch_condition = "WAF_Prefetch"
     response_object    = "WAF_Response"
   }
 

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -180,7 +180,7 @@ resource "fastly_service_v1" "demo" {
 
   # This condition will always be false
   # adding it to the response object created below
-  # prevents Fastly from returning a 403 on all of your traffic
+  # prevents Fastly from returning a 403 on all of your traffic.
   condition {
     name      = "WAF_always_false"
     statement = "false"

--- a/website/docs/r/service_v1.html.markdown
+++ b/website/docs/r/service_v1.html.markdown
@@ -580,8 +580,7 @@ The `waf` block supports:
 * `response_object` - (Required) A Web Application Firewall's (WAF) response object.
 * `prefetch_condition` - (Required) Name of already defined `condition` to apply. This `condition` must be of type `PREFETCH`. 
 For detailed information about Conditionals, see [Fastly's Documentation on Conditionals][fastly-conditionals].
-* `disabled` - (Optional) This flag disables the WAF. Disabling a WAF removes all rules and restore all configuration 
-to its default values. 
+* `disabled` - (Optional) This flag disables the WAF. When a WAF is disabled, all configuration remains but in a inactive state. 
 
 ## Attributes Reference
 

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -180,7 +180,7 @@ resource "fastly_service_v1" "demo" {
     status            = "403"
     response          = "Forbidden"
     content_type      = "text/html"
-    content           = "<html><body>something</body></html>"
+    content           = "<html><body>Forbidden</body></html>"
     request_condition = "WAF_always_false"
   }
   waf {

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -166,7 +166,7 @@ resource "fastly_service_v1" "demo" {
     statement = "req.backend.is_origin"
   }
 
-  # this condition will always be false
+  # This condition will always be false
   # adding it to the response object created below
   # prevents Fastly from returning a 403 on all of your traffic
   condition {

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -41,7 +41,7 @@ resource "fastly_service_v1" "demo" {
     statement = "req.backend.is_origin"
   }
 
-  # this condition will always be false
+  # This condition will always be false
   # adding it to the response object created below
   # prevents Fastly from returning a 403 on all of your traffic
   condition {

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -6,14 +6,14 @@ description: |-
   Provides a Web Application Firewall configuration and rules that can be applied to a service. 
 ---
 
+-> **Note:** This page is about v1.1.0 and later of the Fastly terraform provider.
+
 # fastly_service_waf_configuration_v1
 
-Defines a set a Web Application Firewall configuration options that can be used to populate a service waf.  This resource will populate a waf with configuration and waf rules and will track their state.
+Defines a set of Web Application Firewall configuration options that can be used to populate a service WAF.  This resource will populate a WAF with configuration and WAF rules and will track their state.
 
 
-~> **Warning:** Terraform will take precedence over any changes you make in the UI or API. Such changes are likely to be reversed if you run Terraform again.  
-
-If Terraform is being used to populate the initial content of a dictionary which you intend to manage via API or UI, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.    
+~> **Warning:** Terraform will take precedence over any changes you make in the UI or API. Such changes are likely to be reversed if you run Terraform again.    
 
 
 ## Example Usage
@@ -72,6 +72,56 @@ resource "fastly_service_waf_configuration_v1" "waf" {
 ```
 
 Usage with rules:
+
+```hcl
+resource "fastly_service_v1" "demo" {
+  name = "demofastly"
+
+  domain {
+    name    = "demo.notexample.com"
+    comment = "demo"
+  }
+
+  backend {
+    address = "127.0.0.1"
+    name    = "origin1"
+    port    = 80
+  }
+
+  condition {
+    name      = "Waf_Prefetch"
+    type      = "PREFETCH"
+    statement = "req.url~+\"index.html\""
+  }
+
+  response_object {
+    name     = "WAF_Response"
+    status   = "403"
+    response = "Forbidden"
+    content  = "content2"
+  }
+
+  waf {
+    prefetch_condition = "Waf_Prefetch"
+    response_object    = "WAF_Response"
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_waf_configuration_v1" "waf" {
+  waf_id                          = fastly_service_v1.demo.waf[0].waf_id
+  http_violation_score_threshold  = 100
+
+  rule {
+    modsec_rule_id = 1010090
+    revision       = 1
+    status         = "log"
+  }
+}
+```
+
+Usage with rules from datasource:
 
 ```hcl
 variable "type_status" {
@@ -215,40 +265,44 @@ resource "fastly_service_waf_configuration_v1" "waf" {
 
 The following arguments are supported:
 
-* `waf_id` - (Required) The ID of the Web Application Firewall that the configuration belongs to
-* `allowed_http_versions` - (Optional) Allowed HTTP versions (default HTTP/1.0 HTTP/1.1 HTTP/2)
-* `allowed_methods` - (Optional) A space-separated list of HTTP method names (default GET HEAD POST OPTIONS PUT PATCH DELETE)
-* `allowed_request_content_type` - (Optional) Allowed request content types (default application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json|text/plain)
-* `allowed_request_content_type_charset` - (Required) Allowed request content type charset (default utf-8|iso-8859-1|iso-8859-15|windows-1252)
-* `arg_length` - (Optional) The maximum number of arguments allowed (default 400)
-* `arg_name_length` - (Optional) The maximum allowed argument name length (default 100)
-* `combined_file_sizes` - (Optional) The maximum allowed size of all files (in bytes, default 10000000)
-* `critical_anomaly_score` - (Optional) Score value to add for critical anomalies (default 6)
-* `crs_validate_utf8_encoding` - (Optional) CRS validate UTF8 encoding
-* `error_anomaly_score` - (Optional) Score value to add for error anomalies (default 5)
-* `high_risk_country_codes` - (Optional) A space-separated list of country codes in ISO 3166-1 (two-letter) format
-* `http_violation_score_threshold` - (Optional) HTTP violation threshold
-* `inbound_anomaly_score_threshold` - (Optional) Inbound anomaly threshold
-* `lfi_score_threshold` - (Optional) Local file inclusion attack threshold
-* `max_file_size` - (Optional) The maximum allowed file size, in bytes (default 10000000)
-* `max_num_args` - (Optional) The maximum number of arguments allowed (default 255)
-* `notice_anomaly_score` - (Optional) Score value to add for notice anomalies (default 4)
-* `paranoia_level` - (Optional) The configured paranoia level (default 1)
-* `php_injection_score_threshold` - (Optional) PHP injection threshold
-* `rce_score_threshold` - (Optional) Remote code execution threshold
-* `restricted_extensions` - (Optional) A space-separated list of allowed file extensions (default .asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx)
-* `restricted_headers` - (Optional) A space-separated list of allowed header names (default /proxy/ /lock-token/ /content-range/ /translate/ /if/)
-* `rfi_score_threshold` - (Optional) Remote file inclusion attack threshold
-* `session_fixation_score_threshold` - (Optional) Session fixation attack threshold
-* `sql_injection_score_threshold` - (Optional) SQL injection attack threshold
-* `total_arg_length` - (Optional) The maximum size of argument names and values (default 6400)
-* `warning_anomaly_score` - (Optional) Score value to add for warning anomalies
-* `xss_score_threshold` - (Optional) XSS attack threshold
+* `waf_id` - (Required) The ID of the Web Application Firewall that the configuration belongs to.
+* `allowed_http_versions` - (Optional) Allowed HTTP versions.
+* `allowed_methods` - (Optional) A space-separated list of HTTP method names.
+* `allowed_request_content_type` - (Optional) Allowed request content types.
+* `allowed_request_content_type_charset` - (Required) Allowed request content type charset.
+* `arg_length` - (Optional) The maximum number of arguments allowed.
+* `arg_name_length` - (Optional) The maximum allowed argument name length.
+* `combined_file_sizes` - (Optional) The maximum allowed size of all files.
+* `critical_anomaly_score` - (Optional) Score value to add for critical anomalies.
+* `crs_validate_utf8_encoding` - (Optional) CRS validate UTF8 encoding.
+* `error_anomaly_score` - (Optional) Score value to add for error anomalies.
+* `high_risk_country_codes` - (Optional) A space-separated list of country codes in ISO 3166-1 (two-letter) format.
+* `http_violation_score_threshold` - (Optional) HTTP violation threshold.
+* `inbound_anomaly_score_threshold` - (Optional) Inbound anomaly threshold.
+* `lfi_score_threshold` - (Optional) Local file inclusion attack threshold.
+* `max_file_size` - (Optional) The maximum allowed file size, in bytes.
+* `max_num_args` - (Optional) The maximum number of arguments allowed.
+* `notice_anomaly_score` - (Optional) Score value to add for notice anomalies.
+* `paranoia_level` - (Optional) The configured paranoia level.
+* `php_injection_score_threshold` - (Optional) PHP injection threshold.
+* `rce_score_threshold` - (Optional) Remote code execution threshold.
+* `restricted_extensions` - (Optional) A space-separated list of allowed file extensions.
+* `restricted_headers` - (Optional) A space-separated list of allowed header names.
+* `rfi_score_threshold` - (Optional) Remote file inclusion attack threshold.
+* `session_fixation_score_threshold` - (Optional) Session fixation attack threshold.
+* `sql_injection_score_threshold` - (Optional) SQL injection attack threshold.
+* `total_arg_length` - (Optional) The maximum size of argument names and values.
+* `warning_anomaly_score` - (Optional) Score value to add for warning anomalies.
+* `xss_score_threshold` - (Optional) XSS attack threshold.
+* `rule` - (Optional) The Web Application Firewall's active rules.
 
 
-## Attributes Reference
+The `rule` block supports:
 
-* [fastly-waf-configuration](https://docs.fastly.com/api/ngwaf#api-section-ngwaf_firewall_versions)
+* `status` - (Required) The Web Application Firewall rule's status. Allowed values are (log, block and score).
+* `modsec_rule_id` - (Required) The Web Application Firewall rule's modsecurity ID.
+* `revision` - (Required) The Web Application Firewall rule's revision.
+
 
 ## Import
 
@@ -259,7 +313,7 @@ The resource ID should be the WAF ID.
 $ terraform import fastly_service_waf_configuration_v1.waf xxxxxxxxxxxxxxxxxxxx
 ```
 
-If Terraform is already managing remote waf configurations against a resource being imported then the user will be asked to remove it from the existing Terraform state.  
+If Terraform is already managing a remote WAF configurations against a resource being imported then the user will be asked to remove it from the existing Terraform state.  
 The following is an example of the Terraform state command to remove the resource named `fastly_service_waf_configuration_v1.waf` from the Terraform state file.
 
 ```

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -55,7 +55,7 @@ resource "fastly_service_v1" "demo" {
     status            = "403"
     response          = "Forbidden"
     content_type      = "text/html"
-    content           = "<html><body>something</body></html>"
+    content           = "<html><body>Forbidden</body></html>"
     request_condition = "WAF_always_false"
   }
 

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -421,7 +421,7 @@ The following arguments are supported:
 
 The `rule` block supports:
 
-* `status` - (Required) The Web Application Firewall rule's status. Allowed values are (log, block and score).
+* `status` - (Required) The Web Application Firewall rule's status. Allowed values are (`log`, `block` and `score`).
 * `modsec_rule_id` - (Required) The Web Application Firewall rule's modsecurity ID.
 * `revision` - (Optional) The Web Application Firewall rule's revision. The latest revision will be used if this is not provided.
 

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 # fastly_service_waf_configuration_v1
 
-Defines a set of Web Application Firewall configuration options that can be used to populate a service WAF.  This resource will populate a WAF with configuration and WAF rules and will track their state.
+Defines a set of Web Application Firewall configuration options that can be used to populate a service WAF. This resource will configure rules, thresholds and other settings for a WAF.
 
 
 ~> **Warning:** Terraform will take precedence over any changes you make in the UI or API. Such changes are likely to be reversed if you run Terraform again.    
@@ -121,7 +121,7 @@ resource "fastly_service_waf_configuration_v1" "waf" {
 }
 ```
 
-Usage with rules from datasource:
+Usage with rules from data source:
 
 ```hcl
 variable "type_status" {
@@ -187,9 +187,10 @@ resource "fastly_service_waf_configuration_v1" "waf" {
 }
 ```
 
-Usage with rules set individually:
+Usage with support for individual rule configuration (this is the suggested pattern):
 
 ```hcl
+// this variable is used for rule configuration in bulk
 variable "type_status" {
   type = map(string)
   default = {
@@ -198,7 +199,7 @@ variable "type_status" {
     strict    = "log"
   }
 }
-
+// this variable is used for individual rule configuration
 variable "individual_rules" {
   type = map(string)
   default = {
@@ -254,6 +255,7 @@ resource "fastly_service_waf_configuration_v1" "waf" {
     content {
       modsec_rule_id = rule.value.modsec_rule_id
       revision       = rule.value.latest_revision_number
+      // Nested lookups in order to apply a combination of in bulk and individual rule configuration
       status         = lookup(var.individual_rules, rule.value.modsec_rule_id, lookup(var.type_status, rule.value.type, "log"))
     }
   }

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -264,7 +264,7 @@ resource "fastly_service_v1" "demo" {
     status            = "403"
     response          = "Forbidden"
     content_type      = "text/html"
-    content           = "<html><body>something</body></html>"
+    content           = "<html><body>Forbidden</body></html>"
     request_condition = "WAF_always_false"
   }
 

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Web Application Firewall configuration and rules that can be applied to a service. 
 ---
 
--> **Note:** This page is about v1.1.0 and later of the Fastly terraform provider.
+-> **Note:** This resource is only available from x.x.x of the Fastly terraform provider.
 
 # fastly_service_waf_configuration_v1
 

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -250,7 +250,7 @@ resource "fastly_service_v1" "demo" {
     statement = "req.backend.is_origin"
   }
 
-  # this condition will always be false
+  # This condition will always be false
   # adding it to the response object created below
   # prevents Fastly from returning a 403 on all of your traffic
   condition {

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -21,15 +21,6 @@ Defines a set of Web Application Firewall configuration options that can be used
 Basic usage:
 
 ```hcl
-variable "type_status" {
-  type = map(string)
-  default = {
-    score     = "score"
-    threshold = "log"
-    strict    = "log"
-  }
-}
-
 resource "fastly_service_v1" "demo" {
   name = "demofastly"
 
@@ -47,14 +38,24 @@ resource "fastly_service_v1" "demo" {
   condition {
     name      = "Waf_Prefetch"
     type      = "PREFETCH"
-    statement = "req.url~+\"index.html\""
+    statement = "req.backend.is_origin"
+  }
+
+  # this condition will always be false
+  # adding it to the response object created below
+  # prevents Fastly from returning a 403 on all of your traffic
+  condition {
+    name      = "WAF_always_false"
+    statement = "false"
+    type      = "REQUEST"
   }
 
   response_object {
     name     = "WAF_Response"
     status   = "403"
     response = "Forbidden"
-    content  = "content2"
+    content  = "content"
+    request_condition = "WAF_always_false"
   }
 
   waf {
@@ -91,14 +92,24 @@ resource "fastly_service_v1" "demo" {
   condition {
     name      = "Waf_Prefetch"
     type      = "PREFETCH"
-    statement = "req.url~+\"index.html\""
+    statement = "req.backend.is_origin"
+  }
+
+  # this condition will always be false
+  # adding it to the response object created below
+  # prevents Fastly from returning a 403 on all of your traffic
+  condition {
+    name      = "WAF_always_false"
+    statement = "false"
+    type      = "REQUEST"
   }
 
   response_object {
     name     = "WAF_Response"
     status   = "403"
     response = "Forbidden"
-    content  = "content2"
+    content  = "content"
+    request_condition = "WAF_always_false"
   }
 
   waf {
@@ -150,14 +161,24 @@ resource "fastly_service_v1" "demo" {
   condition {
     name      = "Waf_Prefetch"
     type      = "PREFETCH"
-    statement = "req.url~+\"index.html\""
+    statement = "req.backend.is_origin"
+  }
+
+  # this condition will always be false
+  # adding it to the response object created below
+  # prevents Fastly from returning a 403 on all of your traffic
+  condition {
+    name      = "WAF_always_false"
+    statement = "false"
+    type      = "REQUEST"
   }
 
   response_object {
     name     = "WAF_Response"
     status   = "403"
     response = "Forbidden"
-    content  = "content2"
+    content  = "content"
+    request_condition = "WAF_always_false"
   }
 
   waf {
@@ -224,14 +245,24 @@ resource "fastly_service_v1" "demo" {
   condition {
     name      = "Waf_Prefetch"
     type      = "PREFETCH"
-    statement = "req.url~+\"index.html\""
+    statement = "req.backend.is_origin"
+  }
+
+  # this condition will always be false
+  # adding it to the response object created below
+  # prevents Fastly from returning a 403 on all of your traffic
+  condition {
+    name      = "WAF_always_false"
+    statement = "false"
+    type      = "REQUEST"
   }
 
   response_object {
     name     = "WAF_Response"
     status   = "403"
     response = "Forbidden"
-    content  = "content2"
+    content  = "content"
+    request_condition = "WAF_always_false"
   }
 
   waf {
@@ -301,14 +332,24 @@ resource "fastly_service_v1" "demo" {
   condition {
     name      = "Waf_Prefetch"
     type      = "PREFETCH"
-    statement = "req.url~+\"index.html\""
+    statement = "req.backend.is_origin"
+  }
+
+  # this condition will always be false
+  # adding it to the response object created below
+  # prevents Fastly from returning a 403 on all of your traffic
+  condition {
+    name      = "WAF_always_false"
+    statement = "false"
+    type      = "REQUEST"
   }
 
   response_object {
     name     = "WAF_Response"
     status   = "403"
     response = "Forbidden"
-    content  = "content2"
+    content  = "content"
+    request_condition = "WAF_always_false"
   }
 
   waf {

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -98,7 +98,7 @@ resource "fastly_service_v1" "demo" {
 
   # This condition will always be false
   # adding it to the response object created below
-  # prevents Fastly from returning a 403 on all of your traffic
+  # prevents Fastly from returning a 403 on all of your traffic.
   condition {
     name      = "WAF_always_false"
     statement = "false"

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -289,7 +289,7 @@ resource "fastly_service_waf_configuration_v1" "waf" {
     content {
       modsec_rule_id = rule.value.modsec_rule_id
       revision       = rule.value.latest_revision_number
-      // Nested lookups in order to apply a combination of in bulk and individual rule configuration
+      // Nested lookups in order to apply a combination of in bulk and individual rule configuration.
       status         = lookup(var.individual_rules, rule.value.modsec_rule_id, lookup(var.type_status, rule.value.type, "log"))
     }
   }

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -43,7 +43,7 @@ resource "fastly_service_v1" "demo" {
 
   # This condition will always be false
   # adding it to the response object created below
-  # prevents Fastly from returning a 403 on all of your traffic
+  # prevents Fastly from returning a 403 on all of your traffic.
   condition {
     name      = "WAF_always_false"
     statement = "false"

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -110,7 +110,7 @@ resource "fastly_service_v1" "demo" {
     status            = "403"
     response          = "Forbidden"
     content_type      = "text/html"
-    content           = "<html><body>something</body></html>"
+    content           = "<html><body>Forbidden</body></html>"
     request_condition = "WAF_always_false"
   }
 

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -309,7 +309,7 @@ variable "type_status" {
   }
 }
 
-// this variable is used for individual rule revision configuration
+// This variable is used for individual rule revision configuration.
 variable "specific_rule_revisions" {
   type = map(string)
   default = {

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -313,7 +313,7 @@ variable "type_status" {
 variable "specific_rule_revisions" {
   type = map(string)
   default = {
-    //  if the revision requested is not found, the server will return a 404 response code
+    //  If the revision requested is not found, the server will return a 404 response code.
     1010020 = 1
   }
 }

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -352,7 +352,7 @@ resource "fastly_service_v1" "demo" {
     status            = "403"
     response          = "Forbidden"
     content_type      = "text/html"
-    content           = "<html><body>something</body></html>"
+    content           = "<html><body>Forbidden</body></html>"
     request_condition = "WAF_always_false"
   }
 

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -36,7 +36,7 @@ resource "fastly_service_v1" "demo" {
   }
 
   condition {
-    name      = "Waf_Prefetch"
+    name      = "WAF_Prefetch"
     type      = "PREFETCH"
     statement = "req.backend.is_origin"
   }
@@ -51,15 +51,16 @@ resource "fastly_service_v1" "demo" {
   }
 
   response_object {
-    name     = "WAF_Response"
-    status   = "403"
-    response = "Forbidden"
-    content  = "content"
+    name              = "WAF_Response"
+    status            = "403"
+    response          = "Forbidden"
+    content_type      = "text/html"
+    content           = "<html><body>something</body></html>"
     request_condition = "WAF_always_false"
   }
 
   waf {
-    prefetch_condition = "Waf_Prefetch"
+    prefetch_condition = "WAF_Prefetch"
     response_object    = "WAF_Response"
   }
 
@@ -90,7 +91,7 @@ resource "fastly_service_v1" "demo" {
   }
 
   condition {
-    name      = "Waf_Prefetch"
+    name      = "WAF_Prefetch"
     type      = "PREFETCH"
     statement = "req.backend.is_origin"
   }
@@ -105,15 +106,16 @@ resource "fastly_service_v1" "demo" {
   }
 
   response_object {
-    name     = "WAF_Response"
-    status   = "403"
-    response = "Forbidden"
-    content  = "content"
+    name              = "WAF_Response"
+    status            = "403"
+    response          = "Forbidden"
+    content_type      = "text/html"
+    content           = "<html><body>something</body></html>"
     request_condition = "WAF_always_false"
   }
 
   waf {
-    prefetch_condition = "Waf_Prefetch"
+    prefetch_condition = "WAF_Prefetch"
     response_object    = "WAF_Response"
   }
 
@@ -159,7 +161,7 @@ resource "fastly_service_v1" "demo" {
   }
 
   condition {
-    name      = "Waf_Prefetch"
+    name      = "WAF_Prefetch"
     type      = "PREFETCH"
     statement = "req.backend.is_origin"
   }
@@ -174,15 +176,15 @@ resource "fastly_service_v1" "demo" {
   }
 
   response_object {
-    name     = "WAF_Response"
-    status   = "403"
-    response = "Forbidden"
-    content  = "content"
+    name              = "WAF_Response"
+    status            = "403"
+    response          = "Forbidden"
+    content_type      = "text/html"
+    content           = "<html><body>something</body></html>"
     request_condition = "WAF_always_false"
   }
-
   waf {
-    prefetch_condition = "Waf_Prefetch"
+    prefetch_condition = "WAF_Prefetch"
     response_object    = "WAF_Response"
   }
 
@@ -243,7 +245,7 @@ resource "fastly_service_v1" "demo" {
   }
 
   condition {
-    name      = "Waf_Prefetch"
+    name      = "WAF_Prefetch"
     type      = "PREFETCH"
     statement = "req.backend.is_origin"
   }
@@ -258,15 +260,16 @@ resource "fastly_service_v1" "demo" {
   }
 
   response_object {
-    name     = "WAF_Response"
-    status   = "403"
-    response = "Forbidden"
-    content  = "content"
+    name              = "WAF_Response"
+    status            = "403"
+    response          = "Forbidden"
+    content_type      = "text/html"
+    content           = "<html><body>something</body></html>"
     request_condition = "WAF_always_false"
   }
 
   waf {
-    prefetch_condition = "Waf_Prefetch"
+    prefetch_condition = "WAF_Prefetch"
     response_object    = "WAF_Response"
   }
 
@@ -330,7 +333,7 @@ resource "fastly_service_v1" "demo" {
   }
 
   condition {
-    name      = "Waf_Prefetch"
+    name      = "WAF_Prefetch"
     type      = "PREFETCH"
     statement = "req.backend.is_origin"
   }
@@ -345,15 +348,16 @@ resource "fastly_service_v1" "demo" {
   }
 
   response_object {
-    name     = "WAF_Response"
-    status   = "403"
-    response = "Forbidden"
-    content  = "content"
+    name              = "WAF_Response"
+    status            = "403"
+    response          = "Forbidden"
+    content_type      = "text/html"
+    content           = "<html><body>something</body></html>"
     request_condition = "WAF_always_false"
   }
 
   waf {
-    prefetch_condition = "Waf_Prefetch"
+    prefetch_condition = "WAF_Prefetch"
     response_object    = "WAF_Response"
   }
 

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -303,7 +303,7 @@ The `rule` block supports:
 
 * `status` - (Required) The Web Application Firewall rule's status. Allowed values are (log, block and score).
 * `modsec_rule_id` - (Required) The Web Application Firewall rule's modsecurity ID.
-* `revision` - (Required) The Web Application Firewall rule's revision.
+* `revision` - (Optional) The Web Application Firewall rule's revision. The latest revision will be used if this is not provided.
 
 
 ## Import

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -1,0 +1,125 @@
+---
+layout: "fastly"
+page_title: "Fastly: service_waf_configuration_v1"
+sidebar_current: "docs-fastly-resource-service-waf-configuration-v1"
+description: |-
+  Provides a Web Application Firewall configuration and rules that can be applied to a service. 
+---
+
+# fastly_service_waf_configuration_v1
+
+Defines a set a Web Application Firewall configuration options that can be used to populate a service waf.  This resource will populate a waf with configuration and waf rules and will track their state.
+
+
+~> **Warning:** Terraform will take precedence over any changes you make in the UI or API. Such changes are likely to be reversed if you run Terraform again.  
+
+If Terraform is being used to populate the initial content of a dictionary which you intend to manage via API or UI, then the lifecycle `ignore_changes` field can be used with the resource.  An example of this configuration is provided below.    
+
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+variable "type_status" {
+  type = map(string)
+  default = {
+    score     = "score"
+    threshold = "log"
+    strict    = "log"
+  }
+}
+
+resource "fastly_service_v1" "demo" {
+  name = "demofastly"
+
+  domain {
+    name    = "demo.notexample.com"
+    comment = "demo"
+  }
+
+  backend {
+    address = "127.0.0.1"
+    name    = "origin1"
+    port    = 80
+  }
+
+  condition {
+    name      = "Waf_Prefetch"
+    type      = "PREFETCH"
+    statement = "req.url~+\"index.html\""
+  }
+
+  response_object {
+    name     = "WAF_Response"
+    status   = "403"
+    response = "Forbidden"
+    content  = "content2"
+  }
+
+  waf {
+    prefetch_condition = "Waf_Prefetch"
+    response_object    = "WAF_Response"
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_waf_configuration_v1" "waf" {
+
+  waf_id                          = fastly_service_v1.foo.waf[0].waf_id
+  http_violation_score_threshold  = 100
+
+  dynamic "rule" {
+    for_each = data.fastly_waf_rules.r1.rules
+
+    content {
+      modsec_rule_id = rule.value.modsec_rule_id
+      revision       = rule.value.latest_revision_number
+      status         = lookup(var.type_status, rule.value.type, "log")
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `waf_id` - (Required) The ID of the Web Application Firewall that the configuration belongs to
+* `allowed_http_versions` - (Optional) Allowed HTTP versions (default HTTP/1.0 HTTP/1.1 HTTP/2)
+* `allowed_methods` - (Optional) A space-separated list of HTTP method names (default GET HEAD POST OPTIONS PUT PATCH DELETE)
+* `allowed_request_content_type` - (Optional) Allowed request content types (default application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json|text/plain)
+* `allowed_request_content_type_charset` - (Required) Allowed request content type charset (default utf-8|iso-8859-1|iso-8859-15|windows-1252)
+* `arg_length` - (Optional) The maximum number of arguments allowed (default 400)
+* `arg_name_length` - (Optional) The maximum allowed argument name length (default 100)
+* `combined_file_sizes` - (Optional) The maximum allowed size of all files (in bytes, default 10000000)
+* `critical_anomaly_score` - (Optional) Score value to add for critical anomalies (default 6)
+* `crs_validate_utf8_encoding` - (Optional) CRS validate UTF8 encoding
+* `error_anomaly_score` - (Optional) Score value to add for error anomalies (default 5)
+* `high_risk_country_codes` - (Optional) A space-separated list of country codes in ISO 3166-1 (two-letter) format
+* `http_violation_score_threshold` - (Optional) HTTP violation threshold
+* `inbound_anomaly_score_threshold` - (Optional) Inbound anomaly threshold
+* `lfi_score_threshold` - (Optional) Local file inclusion attack threshold
+* `max_file_size` - (Optional) The maximum allowed file size, in bytes (default 10000000)
+* `max_num_args` - (Optional) The maximum number of arguments allowed (default 255)
+* `notice_anomaly_score` - (Optional) Score value to add for notice anomalies (default 4)
+* `paranoia_level` - (Optional) The configured paranoia level (default 1)
+* `php_injection_score_threshold` - (Optional) PHP injection threshold
+* `rce_score_threshold` - (Optional) Remote code execution threshold
+* `restricted_extensions` - (Optional) A space-separated list of allowed file extensions (default .asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx)
+* `restricted_headers` - (Optional) A space-separated list of allowed header names (default /proxy/ /lock-token/ /content-range/ /translate/ /if/)
+* `rfi_score_threshold` - (Optional) Remote file inclusion attack threshold
+* `session_fixation_score_threshold` - (Optional) Session fixation attack threshold
+* `sql_injection_score_threshold` - (Optional) SQL injection attack threshold
+* `total_arg_length` - (Optional) The maximum size of argument names and values (default 6400)
+* `warning_anomaly_score` - (Optional) Score value to add for warning anomalies
+* `xss_score_threshold` - (Optional) XSS attack threshold
+
+
+## Attributes Reference
+
+* [fastly-waf_configuration](https://docs.fastly.com/api/ngwaf#api-section-ngwaf_firewall_versions)
+
+## Import
+ 

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -340,7 +340,7 @@ resource "fastly_service_v1" "demo" {
 
   # This condition will always be false
   # adding it to the response object created below
-  # prevents Fastly from returning a 403 on all of your traffic
+  # prevents Fastly from returning a 403 on all of your traffic.
   condition {
     name      = "WAF_always_false"
     statement = "false"

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -252,7 +252,7 @@ resource "fastly_service_v1" "demo" {
 
   # This condition will always be false
   # adding it to the response object created below
-  # prevents Fastly from returning a 403 on all of your traffic
+  # prevents Fastly from returning a 403 on all of your traffic.
   condition {
     name      = "WAF_always_false"
     statement = "false"

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -168,7 +168,7 @@ resource "fastly_service_v1" "demo" {
 
   # This condition will always be false
   # adding it to the response object created below
-  # prevents Fastly from returning a 403 on all of your traffic
+  # prevents Fastly from returning a 403 on all of your traffic.
   condition {
     name      = "WAF_always_false"
     statement = "false"

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -96,7 +96,7 @@ resource "fastly_service_v1" "demo" {
     statement = "req.backend.is_origin"
   }
 
-  # this condition will always be false
+  # This condition will always be false
   # adding it to the response object created below
   # prevents Fastly from returning a 403 on all of your traffic
   condition {

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -338,7 +338,7 @@ resource "fastly_service_v1" "demo" {
     statement = "req.backend.is_origin"
   }
 
-  # this condition will always be false
+  # This condition will always be false
   # adding it to the response object created below
   # prevents Fastly from returning a 403 on all of your traffic
   condition {

--- a/website/docs/r/service_waf_configuration_v1.html.markdown
+++ b/website/docs/r/service_waf_configuration_v1.html.markdown
@@ -25,7 +25,7 @@ resource "fastly_service_v1" "demo" {
   name = "demofastly"
 
   domain {
-    name    = "demo.notexample.com"
+    name    = "example.com"
     comment = "demo"
   }
 
@@ -79,7 +79,7 @@ resource "fastly_service_v1" "demo" {
   name = "demofastly"
 
   domain {
-    name    = "demo.notexample.com"
+    name    = "example.com"
     comment = "demo"
   }
 
@@ -148,7 +148,7 @@ resource "fastly_service_v1" "demo" {
   name = "demofastly"
 
   domain {
-    name    = "demo.notexample.com"
+    name    = "example.com"
     comment = "demo"
   }
 
@@ -232,7 +232,7 @@ resource "fastly_service_v1" "demo" {
   name = "demofastly"
 
   domain {
-    name    = "demo.notexample.com"
+    name    = "example.com"
     comment = "demo"
   }
 
@@ -319,7 +319,7 @@ resource "fastly_service_v1" "demo" {
   name = "demofastly"
 
   domain {
-    name    = "demo.notexample.com"
+    name    = "example.com"
     comment = "demo"
   }
 

--- a/website/fastly.erb
+++ b/website/fastly.erb
@@ -35,6 +35,9 @@
                         <li<%= sidebar_current("docs-fastly-resource-service-dynamic-snippet-content-v1") %>>
                             <a href="/docs/providers/fastly/r/service_dynamic_snippet_content_v1.html">fastly_service_dynamic_snippet_content_v1</a>
                         </li>
+                        <li<%= sidebar_current("docs-fastly-resource-service-waf-configuration-v1") %>>
+                            <a href="/docs/providers/fastly/r/service_waf_configuration_v1.html">fastly_service_waf_configuration_v1</a>
+                        </li>
                     </ul>
 
                 </li>

--- a/website/fastly.erb
+++ b/website/fastly.erb
@@ -16,6 +16,9 @@
                         <li<%= sidebar_current("docs-fastly-datasource-ip_ranges") %>>
                             <a href="/docs/providers/fastly/d/ip_ranges.html">fastly_ip_ranges</a>
                         </li>
+                        <li<%= sidebar_current("docs-fastly-datasource-waf_rules") %>>
+                            <a href="/docs/providers/fastly/d/waf_rules.html">fastly_waf_rules</a>
+                        </li>
                     </ul>
                 </li>
 


### PR DESCRIPTION
This PR contains the website documentation for the WAF related functionality. it has a number of examples already, but more can be added if necessary. The documentation has links to API documentation as it is currently. This links may need updating if the URL is changed. All pages which contain WAF related information have a note specifying the version it applies (version written as x.x.x needs to be changed when we know the version) 