### PR TITLE
Active rules post update

### DIFF
--- a/fastly/block_fastly_waf_configuration_v1_active_rule.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule.go
@@ -26,6 +26,7 @@ var activeRule = &schema.Schema{
 			"revision": {
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Computed:    true,
 				Description: "The Web Application Firewall rule's revision.",
 			},
 		},
@@ -47,7 +48,12 @@ func updateRules(d *schema.ResourceData, meta interface{}, wafID string, Number 
 	oss := os.(*schema.Set)
 	nss := ns.(*schema.Set)
 
-	remove := oss.Difference(nss).List()
+	removeDiff := oss.Difference(nss)
+	intersec := oss.Intersection(nss).List()
+	for _, entry := range intersec {
+		removeDiff.Remove(entry)
+	}
+	remove := removeDiff.List()
 	add := nss.Difference(oss).List()
 
 	log.Print("[INFO] WAF rules update")

--- a/fastly/block_fastly_waf_configuration_v1_active_rule.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule.go
@@ -175,7 +175,7 @@ func flattenWAFActiveRules(rules []*gofastly.WAFActiveRule) []map[string]interfa
 	return rl
 }
 
-// deleteByModSecID makes a copy of the argument "remove" and removes any common (with the same modsec_rule_id) elements with argument "add"
+// deleteByModSecID returns a copy of the argument "remove" with all common (with the same modsec_rule_id) elements with argument "add" removed.
 func deleteByModSecID(remove *schema.Set, add []interface{}) *schema.Set {
 
 	modSecIDs := make(map[int]interface{}, remove.Len())

--- a/fastly/block_fastly_waf_configuration_v1_active_rule.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule.go
@@ -175,6 +175,7 @@ func flattenWAFActiveRules(rules []*gofastly.WAFActiveRule) []map[string]interfa
 	return rl
 }
 
+// deleteByModSecID makes a copy of the argument "remove" and removes any common (with the same modsec_rule_id) elements with argument "add"
 func deleteByModSecID(remove *schema.Set, add []interface{}) *schema.Set {
 
 	modSecIDs := make(map[int]interface{}, remove.Len())

--- a/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
@@ -353,7 +353,7 @@ func testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules []gofastly.WAFAc
 		rule := fmt.Sprintf(`
           rule {
             modsec_rule_id = %d
-			revision = %d
+            revision = %d
             status = "%s"
           }`, r.ModSecID, r.Revision, r.Status)
 		result = result + rule

--- a/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
@@ -45,13 +45,6 @@ func TestAccFastlyServiceWAFVersionV1FlattenWAFActiveRules(t *testing.T) {
 	}
 }
 
-func testHashFunc(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%d-", m["modsec_rule_id"].(int)))
-	return hashcode.String(buf.String())
-}
-
 func TestAccFastlyServiceWAFVersionV1FlattenWAFDeleteByModSecID(t *testing.T) {
 
 	addInput := []map[string]interface{}{{"modsec_rule_id": 1}, {"modsec_rule_id": 12}, {"modsec_rule_id": 123}}
@@ -359,4 +352,11 @@ func testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules []gofastly.WAFAc
 		result = result + rule
 	}
 	return result
+}
+
+func testHashFunc(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%d-", m["modsec_rule_id"].(int)))
+	return hashcode.String(buf.String())
 }

--- a/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
@@ -1,6 +1,7 @@
 package fastly
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"sort"
@@ -8,7 +9,9 @@ import (
 
 	gofastly "github.com/fastly/go-fastly/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
@@ -38,6 +41,62 @@ func TestAccFastlyServiceWAFVersionV1FlattenWAFActiveRules(t *testing.T) {
 		out := flattenWAFActiveRules(c.remote)
 		if !reflect.DeepEqual(out, c.local) {
 			t.Fatalf("Error matching:\nexpected: %#v\n     got: %#v", c.local, out)
+		}
+	}
+}
+
+func hash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%d-", m["modsec_rule_id"].(int)))
+	return hashcode.String(buf.String())
+}
+
+func TestAccFastlyServiceWAFVersionV1FlattenWAFDeleteByModSecID(t *testing.T) {
+
+	addInput := []map[string]interface{}{{"modsec_rule_id": 1}, {"modsec_rule_id": 12}, {"modsec_rule_id": 123}}
+	add := make([]interface{}, len(addInput), len(addInput))
+	for i := range addInput {
+		add[i] = addInput[i]
+	}
+
+	deleteInput := []map[string]interface{}{{"modsec_rule_id": 12}, {"modsec_rule_id": 123}, {"modsec_rule_id": 1234}}
+	remove := make([]interface{}, len(deleteInput), len(deleteInput))
+	for i := range deleteInput {
+		remove[i] = deleteInput[i]
+	}
+
+	expectedInput := []map[string]interface{}{{"modsec_rule_id": 1234}}
+	expected := make([]interface{}, len(expectedInput), len(expectedInput))
+	for i := range expectedInput {
+		expected[i] = expectedInput[i]
+	}
+
+	cases := []struct {
+		add      []interface{}
+		remove   *schema.Set
+		expected *schema.Set
+	}{
+		{
+			add:      []interface{}{},
+			remove:   schema.NewSet(hash, []interface{}{}),
+			expected: schema.NewSet(hash, []interface{}{}),
+		},
+		{
+			add:      add,
+			remove:   schema.NewSet(hash, []interface{}{}),
+			expected: schema.NewSet(hash, []interface{}{}),
+		},
+		{
+			add:      add,
+			remove:   schema.NewSet(hash, remove),
+			expected: schema.NewSet(hash, expected),
+		},
+	}
+	for _, c := range cases {
+		out := deleteByModSecID(c.remove, c.add)
+		if !c.expected.Equal(out) {
+			t.Fatalf("Error matching:\nexpected: %#v\n     got: %#v", c.expected, c.remove)
 		}
 	}
 }
@@ -86,34 +145,34 @@ func TestAccFastlyServiceWAFVersionV1UpdateRules(t *testing.T) {
 		{
 			ModSecID: 1010090,
 			Status:   "log",
-			Revision: 1,
+			//Revision: 1,
 		},
 		{
 			ModSecID: 2029718,
 			Status:   "log",
-			Revision: 1,
+			//Revision: 1,
 		},
 		{
 			ModSecID: 2037405,
 			Status:   "log",
-			Revision: 1,
+			//Revision: 1,
 		},
 	}
 	rules2 := []gofastly.WAFActiveRule{
 		{
 			ModSecID: 1010080,
 			Status:   "block",
-			Revision: 1,
+			//Revision: 1,
 		},
 		{
 			ModSecID: 2029718,
 			Status:   "block",
-			Revision: 1,
+			//Revision: 1,
 		},
 		{
 			ModSecID: 2037405,
 			Status:   "block",
-			Revision: 1,
+			//Revision: 1,
 		},
 	}
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
@@ -294,9 +353,8 @@ func testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules []gofastly.WAFAc
 		rule := fmt.Sprintf(`
           rule {
             modsec_rule_id = %d
-            revision = %d
             status = "%s"
-          }`, r.ModSecID, r.Revision, r.Status)
+          }`, r.ModSecID, r.Status)
 		result = result + rule
 	}
 	return result

--- a/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
@@ -84,6 +84,11 @@ func TestAccFastlyServiceWAFVersionV1UpdateRules(t *testing.T) {
 
 	rules1 := []gofastly.WAFActiveRule{
 		{
+			ModSecID: 1010090,
+			Status:   "log",
+			Revision: 1,
+		},
+		{
 			ModSecID: 2029718,
 			Status:   "log",
 			Revision: 1,
@@ -95,6 +100,11 @@ func TestAccFastlyServiceWAFVersionV1UpdateRules(t *testing.T) {
 		},
 	}
 	rules2 := []gofastly.WAFActiveRule{
+		{
+			ModSecID: 1010080,
+			Status:   "block",
+			Revision: 1,
+		},
 		{
 			ModSecID: 2029718,
 			Status:   "block",

--- a/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
@@ -45,7 +45,7 @@ func TestAccFastlyServiceWAFVersionV1FlattenWAFActiveRules(t *testing.T) {
 	}
 }
 
-func hash(v interface{}) int {
+func testHashFunc(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%d-", m["modsec_rule_id"].(int)))
@@ -79,18 +79,18 @@ func TestAccFastlyServiceWAFVersionV1FlattenWAFDeleteByModSecID(t *testing.T) {
 	}{
 		{
 			add:      []interface{}{},
-			remove:   schema.NewSet(hash, []interface{}{}),
-			expected: schema.NewSet(hash, []interface{}{}),
+			remove:   schema.NewSet(testHashFunc, []interface{}{}),
+			expected: schema.NewSet(testHashFunc, []interface{}{}),
 		},
 		{
 			add:      add,
-			remove:   schema.NewSet(hash, []interface{}{}),
-			expected: schema.NewSet(hash, []interface{}{}),
+			remove:   schema.NewSet(testHashFunc, []interface{}{}),
+			expected: schema.NewSet(testHashFunc, []interface{}{}),
 		},
 		{
 			add:      add,
-			remove:   schema.NewSet(hash, remove),
-			expected: schema.NewSet(hash, expected),
+			remove:   schema.NewSet(testHashFunc, remove),
+			expected: schema.NewSet(testHashFunc, expected),
 		},
 	}
 	for _, c := range cases {

--- a/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
@@ -145,34 +145,34 @@ func TestAccFastlyServiceWAFVersionV1UpdateRules(t *testing.T) {
 		{
 			ModSecID: 1010090,
 			Status:   "log",
-			//Revision: 1,
+			Revision: 1,
 		},
 		{
 			ModSecID: 2029718,
 			Status:   "log",
-			//Revision: 1,
+			Revision: 1,
 		},
 		{
 			ModSecID: 2037405,
 			Status:   "log",
-			//Revision: 1,
+			Revision: 1,
 		},
 	}
 	rules2 := []gofastly.WAFActiveRule{
 		{
 			ModSecID: 1010080,
 			Status:   "block",
-			//Revision: 1,
+			Revision: 1,
 		},
 		{
 			ModSecID: 2029718,
 			Status:   "block",
-			//Revision: 1,
+			Revision: 1,
 		},
 		{
 			ModSecID: 2037405,
 			Status:   "block",
-			//Revision: 1,
+			Revision: 1,
 		},
 	}
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
@@ -353,8 +353,9 @@ func testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules []gofastly.WAFAc
 		rule := fmt.Sprintf(`
           rule {
             modsec_rule_id = %d
+			revision = %d
             status = "%s"
-          }`, r.ModSecID, r.Status)
+          }`, r.ModSecID, r.Revision, r.Status)
 		result = result + rule
 	}
 	return result


### PR DESCRIPTION
This PR contains the change to make active rule revision a computed field. Also, the changes to make use of the updated POST API endpoint. The logic change allows for the update of the active rules, where us before everything was a delete and recreation.