### PR TITLE
Adding WAF Exclusions to WAF Configuration resource

### DIFF
--- a/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_active_rule_test.go
@@ -94,43 +94,7 @@ func TestAccFastlyServiceWAFVersionV1FlattenWAFDeleteByModSecID(t *testing.T) {
 	}
 }
 
-func TestAccFastlyServiceWAFVersionV1AddWithRules(t *testing.T) {
-	var service gofastly.ServiceDetail
-	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-
-	rules := []gofastly.WAFActiveRule{
-		{
-			ModSecID: 2029718,
-			Status:   "log",
-			Revision: 1,
-		},
-		{
-			ModSecID: 2037405,
-			Status:   "log",
-			Revision: 1,
-		},
-	}
-	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
-	rulesTF := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules)
-	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckServiceV1Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFastlyServiceWAFVersionV1(name, wafVer),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceV1Exists(serviceRef, &service),
-					testAccCheckFastlyServiceWAFVersionV1CheckRules(&service, rules, 1),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFastlyServiceWAFVersionV1UpdateRules(t *testing.T) {
+func TestAccFastlyServiceWAFVersionV1AddUpdateDeleteRules(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -170,10 +134,10 @@ func TestAccFastlyServiceWAFVersionV1UpdateRules(t *testing.T) {
 	}
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
 	rulesTF1 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules1)
-	wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF1)
+	wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF1, "")
 
 	rulesTF2 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules2)
-	wafVer2 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF2)
+	wafVer2 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF2, "")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -193,100 +157,6 @@ func TestAccFastlyServiceWAFVersionV1UpdateRules(t *testing.T) {
 					testAccCheckServiceV1Exists(serviceRef, &service),
 					testAccCheckFastlyServiceWAFVersionV1CheckRules(&service, rules2, 2),
 				),
-			},
-		},
-	})
-}
-
-func TestAccFastlyServiceWAFVersionV1DeleteRules(t *testing.T) {
-	var service gofastly.ServiceDetail
-	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-
-	rules1 := []gofastly.WAFActiveRule{
-		{
-			ModSecID: 2029718,
-			Status:   "log",
-			Revision: 1,
-		},
-		{
-			ModSecID: 2037405,
-			Status:   "log",
-			Revision: 1,
-		},
-	}
-	rules2 := []gofastly.WAFActiveRule{
-		{
-			ModSecID: 2029718,
-			Status:   "block",
-			Revision: 1,
-		},
-	}
-	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
-	rulesTF1 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules1)
-	wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF1)
-
-	rulesTF2 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules2)
-	wafVer2 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF2)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckServiceV1Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFastlyServiceWAFVersionV1(name, wafVer1),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceV1Exists(serviceRef, &service),
-					testAccCheckFastlyServiceWAFVersionV1CheckRules(&service, rules1, 1),
-				),
-			},
-			{
-				Config: testAccFastlyServiceWAFVersionV1(name, wafVer2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceV1Exists(serviceRef, &service),
-					testAccCheckFastlyServiceWAFVersionV1CheckRules(&service, rules2, 2),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFastlyServiceWAFVersionV1ImportWithRules(t *testing.T) {
-
-	var service gofastly.ServiceDetail
-	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-
-	rules := []gofastly.WAFActiveRule{
-		{
-			ModSecID: 2029718,
-			Status:   "log",
-			Revision: 1,
-		},
-		{
-			ModSecID: 2037405,
-			Status:   "log",
-			Revision: 1,
-		},
-	}
-
-	rulesTF := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules)
-	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(nil, rulesTF)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckServiceV1Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFastlyServiceWAFVersionV1(name, wafVer),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceV1Exists(serviceRef, &service),
-				),
-			},
-			{
-				ResourceName:      "fastly_service_waf_configuration.waf",
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/fastly/block_fastly_waf_configuration_v1_exclusion.go
+++ b/fastly/block_fastly_waf_configuration_v1_exclusion.go
@@ -1,0 +1,212 @@
+package fastly
+
+import (
+	"fmt"
+	gofastly "github.com/fastly/go-fastly/v2/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"log"
+	"strconv"
+)
+
+var wafExclusion = &schema.Schema{
+	Type:     schema.TypeSet,
+	Optional: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the exclusion.",
+			},
+			"condition": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "A conditional expression in VCL used to determine if the condition is met.",
+			},
+			"exclusion_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The type of exclusion.",
+				ValidateFunc: validateExecutionType(),
+			},
+			"modsec_rule_ids": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "The modsec rule ids to exclude.",
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+			},
+			"number": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "A sequential ID assigned to the exclusion.",
+			},
+		},
+	},
+}
+
+func readWAFExclusions(meta interface{}, d *schema.ResourceData, wafVersionNumber int) error {
+	conn := meta.(*FastlyClient).conn
+	wafID := d.Get("waf_id").(string)
+
+	resp, e := conn.ListAllWAFExclusions(&gofastly.ListAllWAFExclusionsInput{
+		WAFID:            wafID,
+		WAFVersionNumber: wafVersionNumber,
+		Include:          strToPtr("waf_rules"),
+	})
+
+	if e != nil {
+		return e
+	}
+
+	err := d.Set("exclusion", flattenWAFExclusions(resp.Items))
+
+	if err != nil {
+		log.Printf("[WARN] Error setting WAF exclusions for (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func flattenWAFExclusions(exclusions []*gofastly.WAFExclusion) []map[string]interface{} {
+	var result []map[string]interface{}
+
+	for _, exclusion := range exclusions {
+
+		m := make(map[string]interface{})
+		if exclusion.Name != nil {
+			m["name"] = *exclusion.Name
+		}
+		if exclusion.Number != nil {
+			m["number"] = *exclusion.Number
+		}
+		if exclusion.Condition != nil {
+			m["condition"] = *exclusion.Condition
+		}
+		if exclusion.ExclusionType != nil {
+			m["exclusion_type"] = *exclusion.ExclusionType
+		}
+
+		var rules []interface{}
+		for _, rule := range exclusion.Rules {
+			rules = append(rules, rule.ModSecID)
+		}
+		if len(rules) > 0 {
+			m["modsec_rule_ids"] = schema.NewSet(schema.HashInt, rules)
+		}
+		result = append(result, m)
+	}
+
+	return result
+}
+
+func updateWAFExclusions(d *schema.ResourceData, meta interface{}, wafID string, wafVersionNumber int) error {
+
+	os, ns := d.GetChange("exclusion")
+
+	if os == nil {
+		os = new(schema.Set)
+	}
+	if ns == nil {
+		ns = new(schema.Set)
+	}
+
+	oss := os.(*schema.Set)
+	nss := ns.(*schema.Set)
+
+	add := nss.Difference(oss).List()
+	remove := oss.Difference(nss).List()
+
+	var err error
+
+	err = deleteWAFExclusion(remove, meta, wafID, wafVersionNumber)
+	if err != nil {
+		return err
+	}
+
+	err = createWAFExclusion(add, meta, wafID, wafVersionNumber)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deleteWAFExclusion(remove []interface{}, meta interface{}, wafID string, wafVersionNumber int) error {
+	conn := meta.(*FastlyClient).conn
+
+	for _, aRaw := range remove {
+		a := aRaw.(map[string]interface{})
+
+		err := conn.DeleteWAFExclusion(&gofastly.DeleteWAFExclusionInput{
+			Number:           a["number"].(int),
+			WAFID:            wafID,
+			WAFVersionNumber: wafVersionNumber,
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func createWAFExclusion(add []interface{}, meta interface{}, wafID string, wafVersionNumber int) error {
+	conn := meta.(*FastlyClient).conn
+
+	for _, aRaw := range add {
+		a := aRaw.(map[string]interface{})
+
+		var rules []*gofastly.WAFRule
+		if a["exclusion_type"] == gofastly.WAFExclusionTypeRule {
+			for _, ruleId := range a["modsec_rule_ids"].(*schema.Set).List() {
+				rules = append(rules, &gofastly.WAFRule{
+					ID: strconv.Itoa(ruleId.(int)),
+				})
+			}
+		} else {
+			rules = nil
+		}
+
+		_, err := conn.CreateWAFExclusion(&gofastly.CreateWAFExclusionInput{
+			WAFID:            wafID,
+			WAFVersionNumber: wafVersionNumber,
+			WAFExclusion: &gofastly.WAFExclusion{
+				Name:          strToPtr(a["name"].(string)),
+				ExclusionType: strToPtr(a["exclusion_type"].(string)),
+				Condition:     strToPtr(a["condition"].(string)),
+				Rules:         rules,
+			},
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateExecutionType() schema.SchemaValidateFunc {
+	return validation.StringInSlice(
+		[]string{
+			gofastly.WAFExclusionTypeRule,
+			gofastly.WAFExclusionTypeWAF,
+		},
+		false,
+	)
+}
+
+func validateWAFExclusion(d *schema.ResourceDiff) error {
+	for _, i := range d.Get("exclusion").(*schema.Set).List() {
+		wafExclusion := i.(map[string]interface{})
+
+		if wafExclusion["exclusion_type"] == gofastly.WAFExclusionTypeWAF && len(wafExclusion["modsec_rule_ids"].(*schema.Set).List()) > 0 {
+			return fmt.Errorf("must not set \"modsec_rule_ids\" with \"waf\" exclusion type in exclusion \"%s\"", wafExclusion["name"])
+		}
+		if wafExclusion["exclusion_type"] == gofastly.WAFExclusionTypeRule && len(wafExclusion["modsec_rule_ids"].(*schema.Set).List()) == 0 {
+			return fmt.Errorf("must set \"modsec_rule_ids\" with \"rule\" exclusion type in exclusion \"%s\"", wafExclusion["name"])
+		}
+	}
+	return nil
+}

--- a/fastly/block_fastly_waf_configuration_v1_exclusion_test.go
+++ b/fastly/block_fastly_waf_configuration_v1_exclusion_test.go
@@ -1,0 +1,362 @@
+package fastly
+
+import (
+	"fmt"
+	gofastly "github.com/fastly/go-fastly/v2/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestAccFastlyServiceWAFVersionV1FlattenWAFExclusions(t *testing.T) {
+	cases := []struct {
+		remote []*gofastly.WAFExclusion
+		local  []map[string]interface{}
+	}{
+		{
+			remote: []*gofastly.WAFExclusion{
+				{
+					ID:            "abc",
+					Number:        intToPtr(1),
+					Name:          strToPtr("index page"),
+					ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+					Condition:     strToPtr("req.url.basename == \"index.html\""),
+					Rules: []*gofastly.WAFRule{
+						{
+							ID:       "2029718",
+							ModSecID: 2029718,
+						},
+						{
+							ID:       "1010070",
+							ModSecID: 1010070,
+						},
+					},
+				},
+				{
+					ID:            "def",
+					Number:        intToPtr(2),
+					Name:          strToPtr("index php"),
+					ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+					Condition:     strToPtr("req.url.basename == \"index.php\""),
+					Rules: []*gofastly.WAFRule{
+						{
+							ID:       "1010070",
+							ModSecID: 1010070,
+						},
+					},
+				},
+				{
+					ID:            "ghi",
+					Number:        intToPtr(3),
+					Name:          strToPtr("index asp"),
+					ExclusionType: strToPtr(gofastly.WAFExclusionTypeWAF),
+					Condition:     strToPtr("req.url.basename == \"index.asp\""),
+				},
+			},
+			local: []map[string]interface{}{
+				{
+					"number":          1,
+					"name":            "index page",
+					"exclusion_type":  "rule",
+					"condition":       "req.url.basename == \"index.html\"",
+					"modsec_rule_ids": schema.NewSet(schema.HashInt, []interface{}{2029718, 1010070}),
+				},
+				{
+					"number":          2,
+					"name":            "index php",
+					"exclusion_type":  "rule",
+					"condition":       "req.url.basename == \"index.php\"",
+					"modsec_rule_ids": schema.NewSet(schema.HashInt, []interface{}{1010070}),
+				},
+				{
+					"number":         3,
+					"name":           "index asp",
+					"exclusion_type": "waf",
+					"condition":      "req.url.basename == \"index.asp\"",
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		out := flattenWAFExclusions(c.remote)
+		local := c.local
+		assertEqualsSliceOfMaps(t, out, local)
+	}
+}
+
+func TestAccFastlyServiceWAFVersionV1Validation(t *testing.T) {
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	cases := []struct {
+		exclusions      []gofastly.WAFExclusion
+		expectedMessage string
+	}{
+		{
+			exclusions: []gofastly.WAFExclusion{
+				{
+					Name:          strToPtr("index page"),
+					ExclusionType: strToPtr(gofastly.WAFExclusionTypeWAF),
+					Condition:     strToPtr("req.url.basename == \"index.html\""),
+					Rules: []*gofastly.WAFRule{
+						{
+							ModSecID: 2029718,
+						},
+					},
+				},
+			},
+			expectedMessage: "must not set \"modsec_rule_ids\" with \"waf\" exclusion type in exclusion \"index page\"",
+		},
+		{
+			exclusions: []gofastly.WAFExclusion{
+				{
+					Name:          strToPtr("index page"),
+					ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+					Condition:     strToPtr("req.url.basename == \"index.html\""),
+				},
+			},
+			expectedMessage: "must set \"modsec_rule_ids\" with \"rule\" exclusion type in exclusion \"index page\"",
+		},
+	}
+
+	for _, c := range cases {
+
+		wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
+		exclusionsTF1 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFExclusions(c.exclusions)
+
+		wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "", exclusionsTF1)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckServiceV1Destroy,
+			Steps: []resource.TestStep{
+				{
+					Config:      testAccFastlyServiceWAFVersionV1(name, wafVer1),
+					ExpectError: regexp.MustCompile(c.expectedMessage),
+				},
+			},
+		})
+
+	}
+}
+
+func TestAccFastlyServiceWAFVersionV1AddUpdateDeleteExclusions(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	rules := []gofastly.WAFActiveRule{
+		{
+			ModSecID: 21032607,
+			Status:   "log",
+			Revision: 1,
+		},
+		{
+			ModSecID: 2029718,
+			Status:   "log",
+			Revision: 1,
+		},
+		{
+			ModSecID: 2037405,
+			Status:   "log",
+			Revision: 1,
+		},
+	}
+
+	exclusions1 := []gofastly.WAFExclusion{
+		{
+			Name:          strToPtr("index page"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			Condition:     strToPtr("req.url.basename == \"index.html\""),
+			Rules: []*gofastly.WAFRule{
+				{
+					ModSecID: 2029718,
+				},
+				{
+					ModSecID: 2037405,
+				},
+			},
+		},
+		{
+			Name:          strToPtr("index php"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			Condition:     strToPtr("req.url.basename == \"index.php\""),
+			Rules: []*gofastly.WAFRule{
+				{
+					ModSecID: 2037405,
+				},
+			},
+		},
+		{
+			Name:          strToPtr("index asp"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeWAF),
+			Condition:     strToPtr("req.url.basename == \"index.asp\""),
+		},
+	}
+
+	exclusions2 := []gofastly.WAFExclusion{
+		{
+			Name:          strToPtr("index page"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			Condition:     strToPtr("req.url.basename == \"index.html\""),
+			Rules: []*gofastly.WAFRule{
+				{
+					ModSecID: 21032607,
+				},
+			},
+		},
+		{
+			Name:          strToPtr("index php"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			Condition:     strToPtr("req.url.basename == \"index.php\""),
+			Rules: []*gofastly.WAFRule{
+				{
+					ModSecID: 2037405,
+				},
+			},
+		},
+		{
+			Name:          strToPtr("index new page"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			Condition:     strToPtr("req.url.basename == \"index-new.html\""),
+			Rules: []*gofastly.WAFRule{
+				{
+					ModSecID: 2037405,
+				},
+			},
+		},
+	}
+
+	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
+	rulesTF := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules)
+	exclusionsTF1 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFExclusions(exclusions1)
+	exclusionsTF2 := testAccCheckFastlyServiceWAFVersionV1ComposeWAFExclusions(exclusions2)
+
+	wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF, exclusionsTF1)
+	wafVer2 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, rulesTF, exclusionsTF2)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFastlyServiceWAFVersionV1(name, wafVer1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists(serviceRef, &service),
+					testAccCheckFastlyServiceWAFVersionV1CheckExclusions(&service, exclusions1, 1),
+				),
+			},
+			{
+				Config: testAccFastlyServiceWAFVersionV1(name, wafVer2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists(serviceRef, &service),
+					testAccCheckFastlyServiceWAFVersionV1CheckExclusions(&service, exclusions2, 2),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFastlyServiceWAFVersionV1CheckExclusions(service *gofastly.ServiceDetail, expected []gofastly.WAFExclusion, wafVerNo int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*FastlyClient).conn
+		wafResp, err := conn.ListWAFs(&gofastly.ListWAFsInput{
+			FilterService: service.ID,
+			FilterVersion: service.ActiveVersion.Number,
+		})
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up WAF records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		if len(wafResp.Items) != 1 {
+			return fmt.Errorf("[ERR] Expected waf result size (%d), got (%d)", 1, len(wafResp.Items))
+		}
+
+		waf := wafResp.Items[0]
+		exclResp, err := conn.ListAllWAFExclusions(&gofastly.ListAllWAFExclusionsInput{
+			WAFID:            waf.ID,
+			WAFVersionNumber: wafVerNo,
+			Include:          strToPtr("waf_rules"),
+		})
+		if err != nil {
+			return fmt.Errorf("[ERR] Error looking up WAF records for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
+		}
+
+		actual := exclResp.Items
+		if len(expected) != len(actual) {
+			return fmt.Errorf("Error matching exclusions slice sizes :\nexpected: %#v\ngot: %#v", len(expected), len(actual))
+		}
+
+		sort.Slice(expected, func(i, j int) bool {
+			return *expected[i].Name < *expected[j].Name
+		})
+
+		sort.Slice(actual, func(i, j int) bool {
+			return *actual[i].Name < *actual[j].Name
+		})
+
+		for i, expectedExcl := range expected {
+			actualExcl := actual[i]
+
+			if *expectedExcl.Name != *actualExcl.Name {
+				return fmt.Errorf("Error matching Name:\nexpected: %#v\ngot: %#v", *expectedExcl.Name, *actualExcl.Name)
+			}
+
+			if *expectedExcl.Condition != *actualExcl.Condition {
+				return fmt.Errorf("Error matching Condition:\nexpected: %#v\ngot: %#v", *expectedExcl.Condition, *actualExcl.Condition)
+			}
+
+			if *expectedExcl.ExclusionType != *actualExcl.ExclusionType {
+				return fmt.Errorf("Error matching ExclusionType:\nexpected: %#v\ngot: %#v", *expectedExcl.ExclusionType, *actualExcl.ExclusionType)
+			}
+
+			if len(expectedExcl.Rules) != len(actualExcl.Rules) {
+				return fmt.Errorf("Error matching rules slice sizes :\nexpected: %#v\ngot: %#v", len(expectedExcl.Rules), len(actualExcl.Rules))
+			}
+
+			sort.Slice(expectedExcl.Rules, func(i, j int) bool {
+				return expectedExcl.Rules[i].ModSecID < expectedExcl.Rules[j].ModSecID
+			})
+			sort.Slice(actualExcl.Rules, func(i, j int) bool {
+				return actualExcl.Rules[i].ModSecID < actualExcl.Rules[j].ModSecID
+			})
+
+			for k, expectedRule := range expectedExcl.Rules {
+				actualRule := actualExcl.Rules[k]
+				if expectedRule.ModSecID != actualRule.ModSecID {
+					return fmt.Errorf("Error matching Rule ModsecId:\nexpected: %#v\ngot: %#v", expectedRule.ModSecID, actualRule.ModSecID)
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckFastlyServiceWAFVersionV1ComposeWAFExclusions(exclusions []gofastly.WAFExclusion) string {
+
+	var result string
+	for _, excl := range exclusions {
+		var modsecIds []string
+		for _, r := range excl.Rules {
+			modsecIds = append(modsecIds, strconv.Itoa(r.ModSecID))
+		}
+
+		rule := fmt.Sprintf(`
+          exclusion {
+            name = "%s"
+            condition = "%s"
+            exclusion_type = "%s"
+            modsec_rule_ids = [%s]
+          }`, *excl.Name, strings.ReplaceAll(*excl.Condition, "\"", "\\\""), *excl.ExclusionType, strings.Join(modsecIds, ","))
+		result = result + rule
+	}
+	return result
+}

--- a/fastly/resource_fastly_service_waf_configuration.go
+++ b/fastly/resource_fastly_service_waf_configuration.go
@@ -20,7 +20,7 @@ func resourceServiceWAFConfigurationV1() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourceServiceWAFConfigurationV1Import,
 		},
-
+		CustomizeDiff: validateWAFConfigurationResource,
 		Schema: map[string]*schema.Schema{
 			"waf_id": {
 				Type:        schema.TypeString,
@@ -205,7 +205,8 @@ func resourceServiceWAFConfigurationV1() *schema.Resource {
 				Description:  "XSS attack threshold.",
 				ValidateFunc: validation.IntAtLeast(1),
 			},
-			"rule": activeRule,
+			"rule":      activeRule,
+			"exclusion": wafExclusion,
 		},
 	}
 }
@@ -252,6 +253,12 @@ func resourceServiceWAFConfigurationV1Update(d *schema.ResourceData, meta interf
 		}
 	}
 
+	if d.HasChange("exclusion") {
+		if err := updateWAFExclusions(d, meta, wafID, latestVersion.Number); err != nil {
+			return err
+		}
+	}
+
 	err = conn.DeployWAFVersion(&gofastly.DeployWAFVersionInput{
 		WAFID:            wafID,
 		WAFVersionNumber: latestVersion.Number,
@@ -289,6 +296,10 @@ func resourceServiceWAFConfigurationV1Read(d *schema.ResourceData, meta interfac
 	refreshWAFConfig(d, latestVersion)
 
 	if err := readWAFRules(meta, d, latestVersion.Number); err != nil {
+		return err
+	}
+
+	if err := readWAFExclusions(meta, d, latestVersion.Number); err != nil {
 		return err
 	}
 
@@ -494,4 +505,9 @@ func determineLatestVersion(versions []*gofastly.WAFVersion) (*gofastly.WAFVersi
 	})
 
 	return versions[0], nil
+}
+
+func validateWAFConfigurationResource(d *schema.ResourceDiff, meta interface{}) error {
+	err := validateWAFExclusion(d)
+	return err
 }

--- a/fastly/resource_fastly_service_waf_configuration_test.go
+++ b/fastly/resource_fastly_service_waf_configuration_test.go
@@ -67,7 +67,7 @@ func TestAccFastlyServiceWAFVersionV1Add(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
-	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "")
+	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "", "")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -89,7 +89,7 @@ func TestAccFastlyServiceWAFVersionV1AddExistingService(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
-	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "")
+	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "", "")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -118,10 +118,10 @@ func TestAccFastlyServiceWAFVersionV1Update(t *testing.T) {
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	wafVerInput1 := testAccFastlyServiceWAFVersionV1BuildConfig(20)
-	wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput1, "")
+	wafVer1 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput1, "", "")
 
 	wafVerInput2 := testAccFastlyServiceWAFVersionV1BuildConfig(22)
-	wafVer2 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput2, "")
+	wafVer2 := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput2, "", "")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -150,7 +150,7 @@ func TestAccFastlyServiceWAFVersionV1Delete(t *testing.T) {
 	var service gofastly.ServiceDetail
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	wafVerInput := testAccFastlyServiceWAFVersionV1BuildConfig(20)
-	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "")
+	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(wafVerInput, "", "")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -184,10 +184,56 @@ func TestAccFastlyServiceWAFVersionV1Import(t *testing.T) {
 		"http_violation_score_threshold": 10,
 	}
 
-	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(extraHCLMap, "")
+	rules := []gofastly.WAFActiveRule{
+		{
+			ModSecID: 2029718,
+			Status:   "log",
+			Revision: 1,
+		},
+		{
+			ModSecID: 2037405,
+			Status:   "log",
+			Revision: 1,
+		},
+	}
+
+	exclusions := []gofastly.WAFExclusion{
+		{
+			Name:          strToPtr("index page"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			Condition:     strToPtr("req.url.basename == \"index.html\""),
+			Rules: []*gofastly.WAFRule{
+				{
+					ModSecID: 2029718,
+				},
+				{
+					ModSecID: 2037405,
+				},
+			},
+		},
+		{
+			Name:          strToPtr("index php"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeRule),
+			Condition:     strToPtr("req.url.basename == \"index.php\""),
+			Rules: []*gofastly.WAFRule{
+				{
+					ModSecID: 2037405,
+				},
+			},
+		},
+		{
+			Name:          strToPtr("index asp"),
+			ExclusionType: strToPtr(gofastly.WAFExclusionTypeWAF),
+			Condition:     strToPtr("req.url.basename == \"index.asp\""),
+		},
+	}
+
+	rulesTF := testAccCheckFastlyServiceWAFVersionV1ComposeWAFRules(rules)
+	exclusionsTF := testAccCheckFastlyServiceWAFVersionV1ComposeWAFExclusions(exclusions)
+	wafVer := testAccFastlyServiceWAFVersionV1ComposeConfiguration(extraHCLMap, rulesTF, exclusionsTF)
 	wafSvcCfg := testAccFastlyServiceWAFVersionV1(name, wafVer)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceV1Destroy,
@@ -311,7 +357,7 @@ func testAccFastlyServiceWAFVersionV1GetVersionNumber(versions []*gofastly.WAFVe
 	return gofastly.WAFVersion{}, fmt.Errorf("version number %d not found", number)
 }
 
-func testAccFastlyServiceWAFVersionV1ComposeConfiguration(m map[string]interface{}, rules string) string {
+func testAccFastlyServiceWAFVersionV1ComposeConfiguration(m map[string]interface{}, rules string, exclusions string) string {
 
 	hcl := `
         resource "fastly_service_waf_configuration" "waf" {
@@ -331,8 +377,11 @@ func testAccFastlyServiceWAFVersionV1ComposeConfiguration(m map[string]interface
          `, k, v)
 		}
 	}
-	return hcl + fmt.Sprintf(`%s
-        }`, rules)
+	return hcl + fmt.Sprintf(`
+          %s
+
+          %s
+        }`, rules, exclusions)
 }
 
 func testAccFastlyServiceWAFVersionV1(name, extraHCL string) string {

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
+github.com/fastly/go-fastly v1.17.0 h1:N92pKRkGVWt57f3zMeWijjHnYvFOtT1QvYXhE+NFIhA=
+github.com/fastly/go-fastly v1.17.0/go.mod h1:fwYSSnZ6zEClwRS65T0f57Yh83Tc4gL12GgttQwJZfA=
 github.com/fastly/go-fastly/v2 v2.0.0-alpha.1 h1:ZlYscHQgWQKaDy5WN92z+qAqhex8x7X62JVOAtHCwMk=
 github.com/fastly/go-fastly/v2 v2.0.0-alpha.1/go.mod h1:+gom+YR+9Q5I4biSk/ZjHQGWXxqpRxC3YDVYQcRpZwQ=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=

--- a/vendor/github.com/fastly/go-fastly/v2/fastly/errors.go
+++ b/vendor/github.com/fastly/go-fastly/v2/fastly/errors.go
@@ -117,6 +117,14 @@ var ErrMissingWAFVersionID = errors.New("missing required field 'WAFVersionID'")
 // requires a list of WAF active rules, but it is empty.
 var ErrMissingWAFActiveRuleList = errors.New("WAF active rules slice is empty")
 
+// ErrMissingWAFExclusionNumber is an error that is returned when an input struct
+// requires a "WAFExclusionNumber" key, but one was not set.
+var ErrMissingWAFExclusionNumber = errors.New("missing required field 'WAFExclusionNumber'")
+
+// ErrMissingWAFExclusion is an error that is returned when an input struct
+// requires a "WAFExclusion" key, but one was not set.
+var ErrMissingWAFExclusion = errors.New("missing required field 'WAFExclusion'")
+
 // ErrMissingOWASPID is an error that is returned was an input struct
 // requires a "OWASPID" key, but one was not set
 var ErrMissingOWASPID = errors.New("missing required field 'OWASPID'")

--- a/vendor/github.com/fastly/go-fastly/v2/fastly/waf_exclusion.go
+++ b/vendor/github.com/fastly/go-fastly/v2/fastly/waf_exclusion.go
@@ -1,0 +1,297 @@
+package fastly
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+	"time"
+
+	"github.com/google/jsonapi"
+)
+
+// WAFExclusionType is used for reflection because JSONAPI wants to know what it's
+// decoding into.
+var WAFExclusionType = reflect.TypeOf(new(WAFExclusion))
+
+const (
+	// WAFExclusionTypeRule is the type of WAF exclusions that excludes rules from the WAF based on certain conditions
+	WAFExclusionTypeRule = "rule"
+	// WAFExclusionTypeWAF is the type of WAF exclusions that excludes WAF based on certain conditions
+	WAFExclusionTypeWAF = "waf"
+)
+
+// WAFExclusion is the information about a WAF exclusion object.
+type WAFExclusion struct {
+	ID            string     `jsonapi:"primary,waf_exclusion"`
+	Name          *string    `jsonapi:"attr,name"`
+	ExclusionType *string    `jsonapi:"attr,exclusion_type"`
+	Condition     *string    `jsonapi:"attr,condition"`
+	Number        *int       `jsonapi:"attr,number"`
+	Rules         []*WAFRule `jsonapi:"relation,waf_rules,omitempty"`
+	CreatedAt     *time.Time `jsonapi:"attr,created_at,iso8601,omitempty"`
+	UpdatedAt     *time.Time `jsonapi:"attr,updated_at,iso8601,omitempty"`
+}
+
+// WAFExclusionResponse represents a list of exclusions - full response.
+type WAFExclusionResponse struct {
+	Items []*WAFExclusion
+	Info  infoResponse
+}
+
+// ListWAFExclusionsInput used as input for listing a WAF's exclusions.
+type ListWAFExclusionsInput struct {
+	// The Web Application Firewall's ID.
+	WAFID string
+	// The Web Application Firewall's version number.
+	WAFVersionNumber int
+	// Limit results to exclusions with the specified exclusions type.
+	FilterExclusionType *string
+	// Limit results to exclusions with the specified exclusion name.
+	FilterName *string
+	// Limit results to exclusions that represent the specified ModSecurity modsec_rule_id.
+	FilterModSedID *string
+	// Limit the number of returned pages.
+	PageSize *int
+	// Request a specific page of exclusions.
+	PageNumber *int
+	// Include relationships. Optional, comma-separated values. Permitted values: waf_rule_revision and waf_firewall_version.
+	Include *string
+}
+
+// ListAllWAFExclusionsInput used as input for listing all WAF exclusions.
+type ListAllWAFExclusionsInput struct {
+	// The Web Application Firewall's ID.
+	WAFID string
+	// The Web Application Firewall's version number.
+	WAFVersionNumber int
+	// Limit results to exclusions with the specified exclusions type.
+	FilterExclusionType *string
+	// Limit results to exclusions with the specified exclusion name.
+	FilterName *string
+	// Limit results to exclusions that represent the specified ModSecurity modsec_rule_id.
+	FilterModSedID *string
+	// Include relationships. Optional, comma-separated values. Permitted values: waf_rule_revision and waf_firewall_version.
+	Include *string
+}
+
+// CreateWAFExclusionInput used as input to create a WAF exclusion.
+type CreateWAFExclusionInput struct {
+	// The Web Application Firewall's ID.
+	WAFID string
+	// The Web Application Firewall's version number.
+	WAFVersionNumber int
+	// The Web Application Firewall's exclusion
+	WAFExclusion *WAFExclusion
+}
+
+// UpdateWAFExclusionInput is used for exclusions updates.
+type UpdateWAFExclusionInput struct {
+	// The Web Application Firewall's ID.
+	WAFID string
+	// The Web Application Firewall's version number.
+	WAFVersionNumber int
+	// The exclusion number.
+	Number int
+	// The WAF exclusion
+	WAFExclusion *WAFExclusion
+}
+
+// DeleteWAFExclusionInput used as input for removing WAF exclusions.
+type DeleteWAFExclusionInput struct {
+	// The Web Application Firewall's ID.
+	WAFID string
+	// The Web Application Firewall's version number.
+	WAFVersionNumber int
+	// The exclusion number.
+	Number int
+}
+
+func (i *ListWAFExclusionsInput) formatFilters() map[string]string {
+
+	result := map[string]string{}
+	pairings := map[string]interface{}{
+		"filter[exclusion_type]":           i.FilterExclusionType,
+		"filter[name]":                     i.FilterName,
+		"filter[waf_rules.modsec_rule_id]": i.FilterModSedID,
+		"page[size]":                       i.PageSize,
+		"page[number]":                     i.PageNumber,
+		"include":                          i.Include,
+	}
+
+	for key, value := range pairings {
+		switch value := value.(type) {
+		case *string:
+			if value != nil {
+				result[key] = *value
+			}
+		case *int:
+			if value != nil {
+				result[key] = strconv.Itoa(*value)
+			}
+		}
+	}
+	return result
+}
+
+// ListWAFExclusions returns the list of exclusions for a given WAF ID.
+func (c *Client) ListWAFExclusions(i *ListWAFExclusionsInput) (*WAFExclusionResponse, error) {
+
+	if i.WAFID == "" {
+		return nil, ErrMissingWAFID
+	}
+
+	if i.WAFVersionNumber == 0 {
+		return nil, ErrMissingWAFVersionNumber
+	}
+
+	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/exclusions", i.WAFID, i.WAFVersionNumber)
+	resp, err := c.Get(path, &RequestOptions{
+		Params: i.formatFilters(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	tee := io.TeeReader(resp.Body, &buf)
+
+	info, err := getResponseInfo(tee)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := jsonapi.UnmarshalManyPayload(bytes.NewReader(buf.Bytes()), WAFExclusionType)
+	if err != nil {
+		return nil, err
+	}
+
+	wafExclusions := make([]*WAFExclusion, len(data))
+	for i := range data {
+		typed, ok := data[i].(*WAFExclusion)
+		if !ok {
+			return nil, fmt.Errorf("got back a non-WAFExclusion response")
+		}
+		wafExclusions[i] = typed
+	}
+	return &WAFExclusionResponse{
+		Items: wafExclusions,
+		Info:  info,
+	}, nil
+}
+
+// ListAllWAFExclusions returns the complete list of WAF exclusions for a given WAF ID. It iterates through
+// all existing pages to ensure all WAF exclusions are returned at once.
+func (c *Client) ListAllWAFExclusions(i *ListAllWAFExclusionsInput) (*WAFExclusionResponse, error) {
+
+	if i.WAFID == "" {
+		return nil, ErrMissingWAFID
+	}
+
+	if i.WAFVersionNumber == 0 {
+		return nil, ErrMissingWAFVersionNumber
+	}
+
+	currentPage := 1
+	pageSize := WAFPaginationPageSize
+	result := &WAFExclusionResponse{Items: []*WAFExclusion{}}
+	for {
+		r, err := c.ListWAFExclusions(&ListWAFExclusionsInput{
+			WAFID:               i.WAFID,
+			WAFVersionNumber:    i.WAFVersionNumber,
+			PageNumber:          &currentPage,
+			PageSize:            &pageSize,
+			Include:             i.Include,
+			FilterName:          i.FilterName,
+			FilterModSedID:      i.FilterModSedID,
+			FilterExclusionType: i.FilterExclusionType,
+		})
+		if err != nil {
+			return r, err
+		}
+
+		currentPage++
+		result.Items = append(result.Items, r.Items...)
+
+		if r.Info.Links.Next == "" || len(r.Items) == 0 {
+			return result, nil
+		}
+	}
+}
+
+// CreateWAFExclusion used to create a particular WAF exclusion.
+func (c *Client) CreateWAFExclusion(i *CreateWAFExclusionInput) (*WAFExclusion, error) {
+
+	if i.WAFID == "" {
+		return nil, ErrMissingWAFID
+	}
+
+	if i.WAFVersionNumber == 0 {
+		return nil, ErrMissingWAFVersionNumber
+	}
+
+	if i.WAFExclusion == nil {
+		return nil, ErrMissingWAFExclusion
+	}
+
+	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/exclusions", i.WAFID, i.WAFVersionNumber)
+	resp, err := c.PostJSONAPI(path, i.WAFExclusion, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var wafExclusion WAFExclusion
+	if err := jsonapi.UnmarshalPayload(resp.Body, &wafExclusion); err != nil {
+		return nil, err
+	}
+	return &wafExclusion, nil
+}
+
+// UpdateWAFExclusion used to update a particular WAF exclusion.
+func (c *Client) UpdateWAFExclusion(i *UpdateWAFExclusionInput) (*WAFExclusion, error) {
+	if i.WAFID == "" {
+		return nil, ErrMissingWAFID
+	}
+
+	if i.WAFVersionNumber == 0 {
+		return nil, ErrMissingWAFVersionNumber
+	}
+
+	if i.Number == 0 {
+		return nil, ErrMissingWAFExclusionNumber
+	}
+
+	if i.WAFExclusion == nil {
+		return nil, ErrMissingWAFExclusion
+	}
+
+	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/exclusions/%d", i.WAFID, i.WAFVersionNumber, i.Number)
+	resp, err := c.PatchJSONAPI(path, i.WAFExclusion, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var exc *WAFExclusion
+	if err := decodeBodyMap(resp.Body, &exc); err != nil {
+		return nil, err
+	}
+	return exc, nil
+}
+
+// DeleteWAFExclusions removes rules from a particular WAF.
+func (c *Client) DeleteWAFExclusion(i *DeleteWAFExclusionInput) error {
+	if i.WAFID == "" {
+		return ErrMissingWAFID
+	}
+	if i.WAFVersionNumber == 0 {
+		return ErrMissingWAFVersionNumber
+	}
+	if i.Number == 0 {
+		return ErrMissingWAFExclusionNumber
+	}
+
+	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/exclusions/%d", i.WAFID, i.WAFVersionNumber, i.Number)
+	_, err := c.Delete(path, nil)
+	return err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -366,3 +366,4 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 google.golang.org/grpc/test/bufconn
+# github.com/fastly/go-fastly/v2

--- a/website/docs/r/service_waf_configuration.html.markdown
+++ b/website/docs/r/service_waf_configuration.html.markdown
@@ -134,6 +134,74 @@ resource "fastly_service_waf_configuration" "waf" {
 }
 ```
 
+Usage with exclusions:
+
+```hcl
+resource "fastly_service_v1" "demo" {
+  name = "demofastly"
+
+  domain {
+    name    = "example.com"
+    comment = "demo"
+  }
+
+  backend {
+    address = "127.0.0.1"
+    name    = "origin1"
+    port    = 80
+  }
+
+  condition {
+    name      = "WAF_Prefetch"
+    type      = "PREFETCH"
+    statement = "req.backend.is_origin"
+  }
+
+  # This condition will always be false
+  # adding it to the response object created below
+  # prevents Fastly from returning a 403 on all of your traffic.
+  condition {
+    name      = "WAF_always_false"
+    statement = "false"
+    type      = "REQUEST"
+  }
+
+  response_object {
+    name              = "WAF_Response"
+    status            = "403"
+    response          = "Forbidden"
+    content_type      = "text/html"
+    content           = "<html><body>Forbidden</body></html>"
+    request_condition = "WAF_always_false"
+  }
+
+  waf {
+    prefetch_condition = "WAF_Prefetch"
+    response_object    = "WAF_Response"
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_waf_configuration" "waf" {
+  waf_id                          = fastly_service_v1.demo.waf[0].waf_id
+  http_violation_score_threshold  = 100
+
+  rule {
+    modsec_rule_id = 2029718
+    revision       = 1
+    status         = "log"
+  }
+
+  exclusion {
+    name = "index page"
+    exclusion_type = "rule"
+    condition = "req.url.basename == \"index.html\""
+    modsec_rule_ids = [2029718]
+  }
+}
+```
+
 Usage with rules from data source:
 
 ```hcl
@@ -520,6 +588,7 @@ The following arguments are supported:
 * `warning_anomaly_score` - (Optional) Score value to add for warning anomalies.
 * `xss_score_threshold` - (Optional) XSS attack threshold.
 * `rule` - (Optional) The Web Application Firewall's active rules.
+* `exclusion` - (Optional) The Web Application Firewall's exclusions.
 
 
 The `rule` block supports:
@@ -528,6 +597,16 @@ The `rule` block supports:
 * `modsec_rule_id` - (Required) The Web Application Firewall rule's modsecurity ID.
 * `revision` - (Optional) The Web Application Firewall rule's revision. The latest revision will be used if this is not provided.
 
+The `exclusion` block supports:
+
+* `name` - (Required) The name of exclusion.
+* `exclusion_type` - (Required) The type of exclusion. Values are `rule` to exclude the specified rule(s), or `waf` to disable the Web Application Firewall.
+* `condition` - (Required) A conditional expression in VCL used to determine if the condition is met.
+* `modsec_rule_ids` - (Required) Set of modsecurity IDs to be excluded. No rules should be provided when `exclusion_type` is `waf`. The rules need to be configured on the Web Application Firewall to be excluded.
+
+The `exclusion` block exports:
+
+* `number` - The numeric ID assigned to the WAF Exclusion.
 
 ## Import
 

--- a/website_src/docs/r/service_waf_configuration.html.markdown.tmpl
+++ b/website_src/docs/r/service_waf_configuration.html.markdown.tmpl
@@ -134,6 +134,74 @@ resource "fastly_service_waf_configuration" "waf" {
 }
 ```
 
+Usage with exclusions:
+
+```hcl
+resource "fastly_service_v1" "demo" {
+  name = "demofastly"
+
+  domain {
+    name    = "example.com"
+    comment = "demo"
+  }
+
+  backend {
+    address = "127.0.0.1"
+    name    = "origin1"
+    port    = 80
+  }
+
+  condition {
+    name      = "WAF_Prefetch"
+    type      = "PREFETCH"
+    statement = "req.backend.is_origin"
+  }
+
+  # This condition will always be false
+  # adding it to the response object created below
+  # prevents Fastly from returning a 403 on all of your traffic.
+  condition {
+    name      = "WAF_always_false"
+    statement = "false"
+    type      = "REQUEST"
+  }
+
+  response_object {
+    name              = "WAF_Response"
+    status            = "403"
+    response          = "Forbidden"
+    content_type      = "text/html"
+    content           = "<html><body>Forbidden</body></html>"
+    request_condition = "WAF_always_false"
+  }
+
+  waf {
+    prefetch_condition = "WAF_Prefetch"
+    response_object    = "WAF_Response"
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_service_waf_configuration" "waf" {
+  waf_id                          = fastly_service_v1.demo.waf[0].waf_id
+  http_violation_score_threshold  = 100
+
+  rule {
+    modsec_rule_id = 2029718
+    revision       = 1
+    status         = "log"
+  }
+
+  exclusion {
+    name = "index page"
+    exclusion_type = "rule"
+    condition = "req.url.basename == \"index.html\""
+    modsec_rule_ids = [2029718]
+  }
+}
+```
+
 Usage with rules from data source:
 
 ```hcl
@@ -520,6 +588,7 @@ The following arguments are supported:
 * `warning_anomaly_score` - (Optional) Score value to add for warning anomalies.
 * `xss_score_threshold` - (Optional) XSS attack threshold.
 * `rule` - (Optional) The Web Application Firewall's active rules.
+* `exclusion` - (Optional) The Web Application Firewall's exclusions.
 
 
 The `rule` block supports:
@@ -528,6 +597,16 @@ The `rule` block supports:
 * `modsec_rule_id` - (Required) The Web Application Firewall rule's modsecurity ID.
 * `revision` - (Optional) The Web Application Firewall rule's revision. The latest revision will be used if this is not provided.
 
+The `exclusion` block supports:
+
+* `name` - (Required) The name of exclusion.
+* `exclusion_type` - (Required) The type of exclusion. Values are `rule` to exclude the specified rule(s), or `waf` to disable the Web Application Firewall.
+* `condition` - (Required) A conditional expression in VCL used to determine if the condition is met.
+* `modsec_rule_ids` - (Required) Set of modsecurity IDs to be excluded. No rules should be provided when `exclusion_type` is `waf`. The rules need to be configured on the Web Application Firewall to be excluded.
+
+The `exclusion` block exports:
+
+* `number` - The numeric ID assigned to the WAF Exclusion.
 
 ## Import
 


### PR DESCRIPTION
During this implementation, I've refactored some of the WAF acceptance
tests to reduce overlapping:
1. TestAccFastlyServiceWAFVersionV1ImportWithRules was merged into TestAccFastlyServiceWAFVersionV1Import. This tests was also enhanced to include WAF exclusions

1. TestAccFastlyServiceWAFVersionV1AddWithRules and TestAccFastlyServiceWAFVersionV1DeleteRules was merged into TestAccFastlyServiceWAFVersionV1UpdateRules. The update tests was performing add, update and delete already. TestAccFastlyServiceWAFVersionV1UpdateRules was renamed to TestAccFastlyServiceWAFVersionV1AddUpdateDeleteRules to make it clearer

