### PR TITLE
Add `tls_certificate` data source

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -58,7 +58,11 @@ website:
 website-test:
 	go run "scripts/website/parse-templates.go"
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test build_local clean install_local
+sweep:
+	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
+	go test ./fastly -v -sweep=ALL $(SWEEPARGS) -timeout 30m
+
+.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test sweep build_local clean install_local
 
 PROVIDER_HOSTNAME=registry.terraform.io
 PROVIDER_NAMESPACE=fastly

--- a/fastly/config.go
+++ b/fastly/config.go
@@ -22,7 +22,7 @@ type FastlyClient struct {
 	conn *gofastly.Client
 }
 
-func (c *Config) Client() (interface{}, error) {
+func (c *Config) Client() (*FastlyClient, error) {
 	var client FastlyClient
 
 	if c.ApiKey == "" {

--- a/fastly/data_source_tls_certificate.go
+++ b/fastly/data_source_tls_certificate.go
@@ -1,0 +1,178 @@
+package fastly
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceFastlyTLSCertificate() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceFastlyTLSCertificateRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "Human-readable name used to identify the certificate",
+				Optional:    true,
+				Computed:    true,
+			},
+			"issued_to": {
+				Type:        schema.TypeString,
+				Description: "The hostname for which a certificate was issued",
+				Optional:    true,
+				Computed:    true,
+			},
+			"domains": {
+				Type:        schema.TypeSet,
+				Description: "Domains that are listed in any certificate's Subject Alternative Names (SAN) list",
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"issuer": {
+				Type:        schema.TypeString,
+				Description: "The certificate authority that issued the certificate",
+				Optional:    true,
+				Computed:    true,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Description: "Timestamp (GMT) when the certificate was created",
+				Computed:    true,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Description: "Timestamp (GMT) when the certificate was last updated",
+				Computed:    true,
+			},
+			"replace": {
+				Type:        schema.TypeBool,
+				Description: "A recommendation from Fastly indicating the key associated with this certificate is in need of rotation",
+				Computed:    true,
+			},
+			"serial_number": {
+				Type:        schema.TypeString,
+				Description: "A value assigned by the issuer that is unique to a certificate",
+				Computed:    true,
+			},
+			"signature_algorithm": {
+				Type:        schema.TypeString,
+				Description: "The algorithm used to sign the certificate",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceFastlyTLSCertificateRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	var filters []func(certificate *fastly.CustomTLSCertificate) bool
+
+	if v, ok := d.GetOk("name"); ok {
+		filters = append(filters, func(c *fastly.CustomTLSCertificate) bool {
+			return c.Name == v.(string)
+		})
+	}
+	if v, ok := d.GetOk("issued_to"); ok {
+		filters = append(filters, func(c *fastly.CustomTLSCertificate) bool {
+			return c.IssuedTo == v.(string)
+		})
+	}
+	if v, ok := d.GetOk("domains"); ok {
+		filters = append(filters, func(c *fastly.CustomTLSCertificate) bool {
+			s := v.(*schema.Set)
+			for _, domain := range c.TLSDomains {
+				if s.Contains(domain.ID) {
+					return true
+				}
+			}
+			return false
+		})
+	}
+	if v, ok := d.GetOk("issuer"); ok {
+		filters = append(filters, func(c *fastly.CustomTLSCertificate) bool {
+			return c.Issuer == v.(string)
+		})
+	}
+
+	var certificates []*fastly.CustomTLSCertificate
+	pageNumber := 1
+	for {
+		list, err := conn.ListCustomTLSCertificates(&fastly.ListCustomTLSCertificatesInput{
+			PageNumber: pageNumber,
+			PageSize:   10,
+		})
+		if err != nil {
+			return err
+		}
+		if len(list) == 0 {
+			break
+		}
+		pageNumber++
+
+		for _, certificate := range list {
+			if filterTLSCertificate(certificate, filters) {
+				certificates = append(certificates, certificate)
+			}
+		}
+	}
+
+	if len(certificates) == 0 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	if len(certificates) > 1 {
+		return fmt.Errorf("Your query returned more than one result. Please change try a more specific search criteria and try again.")
+	}
+
+	cert := certificates[0]
+
+	var domains []string
+	for _, domain := range cert.TLSDomains {
+		domains = append(domains, domain.ID)
+	}
+
+	d.SetId(cert.ID)
+	if err := d.Set("name", cert.Name); err != nil {
+		return err
+	}
+	if err := d.Set("created_at", cert.CreatedAt.Format(time.RFC3339)); err != nil {
+		return err
+	}
+	if err := d.Set("updated_at", cert.UpdatedAt.Format(time.RFC3339)); err != nil {
+		return err
+	}
+	if err := d.Set("issued_to", cert.IssuedTo); err != nil {
+		return err
+	}
+	if err := d.Set("issuer", cert.Issuer); err != nil {
+		return err
+	}
+	if err := d.Set("replace", cert.Replace); err != nil {
+		return err
+	}
+	if err := d.Set("serial_number", cert.SerialNumber); err != nil {
+		return err
+	}
+	if err := d.Set("signature_algorithm", cert.SignatureAlgorithm); err != nil {
+		return err
+	}
+	if err := d.Set("domains", domains); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func filterTLSCertificate(config *fastly.CustomTLSCertificate, filters []func(*fastly.CustomTLSCertificate) bool) bool {
+	for _, f := range filters {
+		if !f(config) {
+			return false
+		}
+	}
+	return true
+}

--- a/fastly/data_source_tls_certificate_test.go
+++ b/fastly/data_source_tls_certificate_test.go
@@ -1,0 +1,74 @@
+package fastly
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccFastlyDataSourceTLSCertificate_withName(t *testing.T) {
+	name := acctest.RandomWithPrefix(testResourcePrefix)
+	domain := fmt.Sprintf("%s.example.com", name)
+
+	key, cert, err := generateKeyAndCert(domain)
+	require.NoError(t, err)
+
+	dataSourceName := "data.fastly_tls_certificate.test"
+	resourceName := "fastly_tls_certificate.cert"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceTlsCertificate(name, key, cert, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(
+						dataSourceName, "created_at", resourceName, "created_at"),
+					resource.TestCheckResourceAttrPair(
+						dataSourceName, "updated_at", resourceName, "updated_at"),
+					resource.TestCheckResourceAttrPair(
+						dataSourceName, "issued_to", resourceName, "issued_to"),
+					resource.TestCheckResourceAttrPair(
+						dataSourceName, "issuer", resourceName, "issuer"),
+					resource.TestCheckResourceAttrPair(
+						dataSourceName, "replace", resourceName, "replace"),
+					resource.TestCheckResourceAttrPair(
+						dataSourceName, "serial_number", resourceName, "serial_number"),
+					resource.TestCheckResourceAttrPair(
+						dataSourceName, "signature_algorithm", resourceName, "signature_algorithm"),
+					resource.TestCheckResourceAttrPair(
+						dataSourceName, "domains", resourceName, "domains"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceTlsCertificate(keyName string, key string, cert string, domain string) string {
+	return fmt.Sprintf(`
+resource "fastly_tls_private_key" "key" {
+  name = "%[1]s"
+  key_pem = <<EOF
+%[2]s
+EOF
+}
+
+resource "fastly_tls_certificate" "cert" {
+  name = "%[1]s"
+  certificate_body = <<EOF
+%[3]s
+EOF
+  depends_on = [fastly_tls_private_key.key]
+}
+
+data "fastly_tls_certificate" "test" {
+  name = fastly_tls_certificate.cert.name
+  domains = ["%[4]s"]
+}
+`, keyName, key, cert, domain)
+}

--- a/fastly/data_source_tls_private_key_test.go
+++ b/fastly/data_source_tls_private_key_test.go
@@ -15,7 +15,7 @@ func TestAccFastlyDataSourceTLSPrivateKeyBasic(t *testing.T) {
 	}
 	key = strings.ReplaceAll(key, "\n", `\n`)
 
-	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	name := acctest.RandomWithPrefix(testResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/fastly/provider.go
+++ b/fastly/provider.go
@@ -25,6 +25,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"fastly_ip_ranges":         dataSourceFastlyIPRanges(),
+			"fastly_tls_certificate":   dataSourceFastlyTLSCertificate(),
 			"fastly_tls_configuration": dataSourceFastlyTLSConfiguration(),
 			"fastly_tls_private_key":   dataSourceTLSPrivateKey(),
 			"fastly_waf_rules":         dataSourceFastlyWAFRules(),

--- a/fastly/resource_fastly_tls_certificate_test.go
+++ b/fastly/resource_fastly_tls_certificate_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestAccFastlyTLSCertificate_withName(t *testing.T) {
-	name := fmt.Sprintf("tf-test-%s", acctest.RandString(20))
-	updatedName := fmt.Sprintf("tf-test-%s", acctest.RandString(20))
+	name := acctest.RandomWithPrefix(testResourcePrefix)
+	updatedName := acctest.RandomWithPrefix(testResourcePrefix)
 	domain := fmt.Sprintf("%s.example.com", name)
 
 	key, cert, cert2, err := generateKeyAndMultipleCerts(domain)
@@ -55,7 +55,7 @@ func TestAccFastlyTLSCertificate_withName(t *testing.T) {
 }
 
 func TestAccFastlyTLSCertificate_withoutName(t *testing.T) {
-	name := fmt.Sprintf("tf-test-%s", acctest.RandString(20))
+	name := acctest.RandomWithPrefix(testResourcePrefix)
 	domain := fmt.Sprintf("%s.example.com", name)
 
 	key, cert, err := generateKeyAndCert(domain)

--- a/fastly/resource_tls_private_key_test.go
+++ b/fastly/resource_tls_private_key_test.go
@@ -17,7 +17,7 @@ func TestAccFastlyResourceTLSPrivateKey_basic(t *testing.T) {
 	}
 	key = strings.ReplaceAll(key, "\n", `\n`)
 
-	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	name := acctest.RandomWithPrefix(testResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/fastly/sweeper_test.go
+++ b/fastly/sweeper_test.go
@@ -1,0 +1,111 @@
+package fastly
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+const testResourcePrefix = "tf-test"
+
+var sweeperClients map[string]*fastly.Client
+
+func TestMain(m *testing.M) {
+	sweeperClients = make(map[string]*fastly.Client)
+	resource.TestMain(m)
+}
+
+func sharedClientForRegion(region string) (*fastly.Client, error) {
+	if client, ok := sweeperClients[region]; ok {
+		return client, nil
+	}
+
+	if os.Getenv("FASTLY_API_KEY") == "" {
+		return nil, fmt.Errorf("must provide environment variables 'FASTLY_API_KEY'")
+	}
+
+	url := fastly.DefaultEndpoint
+	if v := os.Getenv("FASTLY_API_URL"); v != "" {
+		url = v
+	}
+	c := Config{
+		ApiKey:           os.Getenv("FASTLY_API_KEY"),
+		BaseURL:          url,
+		terraformVersion: "test-sweepers",
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	sweeperClients[region] = client.conn
+
+	return client.conn, nil
+}
+
+func init() {
+	resource.AddTestSweepers("fastly_tls_private_key", &resource.Sweeper{
+		Name:         "fastly_tls_private_key",
+		Dependencies: []string{"fastly_tls_certificate"}, // in case a private key is used by a certificate
+		F:            testSweepTLSPrivateKeys,
+	})
+	resource.AddTestSweepers("fastly_tls_certificate", &resource.Sweeper{
+		Name: "fastly_tls_certificate",
+		F:    testSweepTLSCertificates,
+	})
+}
+
+func testSweepTLSCertificates(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	certificates, err := client.ListCustomTLSCertificates(&fastly.ListCustomTLSCertificatesInput{PageSize: 1000})
+	if err != nil {
+		return err
+	}
+
+	for _, certificate := range certificates {
+		if !strings.HasPrefix(certificate.Name, testResourcePrefix) {
+			continue
+		}
+
+		err := client.DeleteCustomTLSCertificate(&fastly.DeleteCustomTLSCertificateInput{ID: certificate.ID})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testSweepTLSPrivateKeys(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	keys, err := client.ListPrivateKeys(&fastly.ListPrivateKeysInput{PageSize: 1000})
+	if err != nil {
+		return err
+	}
+
+	for _, key := range keys {
+		if !strings.HasPrefix(key.Name, testResourcePrefix) {
+			continue
+		}
+
+		err := client.DeletePrivateKey(&fastly.DeletePrivateKeyInput{ID: key.ID})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/scripts/website/parse-templates.go
+++ b/scripts/website/parse-templates.go
@@ -44,6 +44,10 @@ func main() {
 			path: docsDir + "docs/d/tls_configuration.html.markdown",
 		},
 		{
+			name: "tls_certificate",
+			path: docsDir + "docs/d/tls_certificate.html.markdown",
+		},
+		{
 			name: "waf_rules",
 			path: docsDir + "docs/d/waf_rules.html.markdown",
 		},

--- a/website/docs/d/tls_certificate.html.markdown
+++ b/website/docs/d/tls_certificate.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "fastly"
+page_title: "Fastly: fastly_tls_certificate"
+sidebar_current: "docs-fastly-datasource-tls_certificate"
+description: |-
+Get information on Fastly TLS certificate.
+---
+
+# fastly_tls_certificate
+
+Use this data source to get information from a TLS certificate for use with other resources.
+
+## Example Usage
+
+```hcl
+data "fastly_tls_certificate" "example" {
+  name = "example.com"
+}
+```
+
+## Argument Reference
+
+~> **Warning:** The data source's filters are applied using an **AND** boolean operator, so depending on the combination of filters, they may become mutually exclusive.
+
+* `name` - (Optional) Human-readable name used to identify the certificate
+* `issued_to` - (Optional) The hostname for which a certificate was issued
+* `domains` - (Optional) Domains that are listed in any certificate's Subject Alternative Names (SAN) list
+* `issuer` - (Optional) The certificate authority that issued the certificate
+
+## Attribute Reference
+
+* `created_at` - Timestamp (GMT) when the certificate was created
+* `updated_at` - Timestamp (GMT) when the certificate was last updated
+* `replace` - A recommendation from Fastly indicating the key associated with this certificate is in need of rotation
+* `serial_number` - A value assigned by the issuer that is unique to a certificate
+* `signature_algorithm` - The algorithm used to sign the certificate

--- a/website/fastly.erb
+++ b/website/fastly.erb
@@ -19,6 +19,9 @@
                         <li<%= sidebar_current("docs-fastly-resource-tls-configuration") %>>
                             <a href="/docs/providers/fastly/d/tls_configuration.html">fastly_tls_configuration</a>
                         </li>
+                        <li<%= sidebar_current("docs-fastly-resource-tls-certificate") %>>
+                            <a href="/docs/providers/fastly/d/tls_certificate.html">fastly_tls_certificate</a>
+                        </li>
                         <li<%= sidebar_current("docs-fastly-resource-waf-rules") %>>
                             <a href="/docs/providers/fastly/d/waf_rules.html">fastly_waf_rules</a>
                         </li>

--- a/website_src/docs/d/tls_certificate.html.markdown.tmpl
+++ b/website_src/docs/d/tls_certificate.html.markdown.tmpl
@@ -1,0 +1,37 @@
+{{define "fastly_data_tls_certificate"}}---
+layout: "fastly"
+page_title: "Fastly: fastly_tls_certificate"
+sidebar_current: "docs-fastly-datasource-tls_certificate"
+description: |-
+Get information on Fastly TLS certificate.
+---
+
+# fastly_tls_certificate
+
+Use this data source to get information of a TLS certificate for use with other resources.
+
+## Example Usage
+
+```hcl
+data "fastly_tls_certificate" "example" {
+  name = "example.com"
+}
+```
+
+## Argument Reference
+
+~> **Warning:** The data source's filters are applied using an **AND** boolean operator, so depending on the combination of filters, they may become mutually exclusive.
+
+* `name` - (Optional) Human-readable name used to identify the certificate
+* `issued_to` - (Optional) The hostname for which a certificate was issued
+* `domains` - (Optional) Domains that are listed in any certificate's Subject Alternative Names (SAN) list
+* `issuer` - (Optional) The certificate authority that issued the certificate
+
+## Attribute Reference
+
+* `created_at` - Timestamp (GMT) when the certificate was created
+* `updated_at` - Timestamp (GMT) when the certificate was last updated
+* `replace` - A recommendation from Fastly indicating the key associated with this certificate is in need of rotation
+* `serial_number` - A value assigned by the issuer that is unique to a certificate
+* `signature_algorithm` - The algorithm used to sign the certificate
+{{end}}


### PR DESCRIPTION
Also add sweepers for TLS certificates and private keys to easily clean up resources leaked during any failed tests.