### PR TITLE
Add conflicts with to ID argument of `fastly_tls_private_key` data source

### DIFF
--- a/fastly/data_source_tls_private_key.go
+++ b/fastly/data_source_tls_private_key.go
@@ -13,46 +13,51 @@ func dataSourceTLSPrivateKey() *schema.Resource {
 		Read: dataSourceTLSPrivateKeyRead,
 		Schema: map[string]*schema.Schema{
 			"id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "Fastly private key ID",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				Description:   "Fastly private key ID",
+				ConflictsWith: []string{"name", "created_at", "key_length", "key_type", "public_key_sha1"},
 			},
 			"name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Customisable name of the private key.",
-				Computed:    true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "Customisable name of the private key.",
+				Computed:      true,
+				ConflictsWith: []string{"id"},
 			},
 			"created_at": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "Timestamp (GMT) when the private key was created.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				Description:   "Timestamp (GMT) when the private key was created.",
+				ConflictsWith: []string{"id"},
 			},
 			"key_length": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Computed:    true,
-				Description: "The key length used to generate the private key.",
+				Type:          schema.TypeInt,
+				Optional:      true,
+				Computed:      true,
+				Description:   "The key length used to generate the private key.",
+				ConflictsWith: []string{"id"},
 			},
 			"key_type": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "The algorithm used to generate the private key. Must be RSA.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				Description:   "The algorithm used to generate the private key. Must be RSA.",
+				ConflictsWith: []string{"id"},
 			},
 			"replace": {
 				Type:        schema.TypeBool,
-				Optional:    true,
 				Computed:    true,
 				Description: "Whether Fastly recommends replacing this private key.",
 			},
 			"public_key_sha1": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "Useful for safely identifying the key.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				Description:   "Useful for safely identifying the key.",
+				ConflictsWith: []string{"id"},
 			},
 		},
 	}
@@ -61,6 +66,44 @@ func dataSourceTLSPrivateKey() *schema.Resource {
 func dataSourceTLSPrivateKeyRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*FastlyClient).conn
 
+	var privateKey *fastly.PrivateKey
+	if v, ok := d.GetOk("id"); ok {
+		var err error
+		privateKey, err = conn.GetPrivateKey(&fastly.GetPrivateKeyInput{ID: v.(string)})
+		if err != nil {
+			return err
+		}
+	} else {
+		var err error
+		privateKey, err = findTLSPrivateKey(conn, d)
+		if err != nil {
+			return err
+		}
+	}
+
+	d.SetId(privateKey.ID)
+	if err := d.Set("name", privateKey.Name); err != nil {
+		return err
+	}
+	if err := d.Set("created_at", privateKey.CreatedAt.Format(time.RFC3339)); err != nil {
+		return err
+	}
+	if err := d.Set("key_length", privateKey.KeyLength); err != nil {
+		return err
+	}
+	if err := d.Set("key_type", privateKey.KeyType); err != nil {
+		return err
+	}
+	if err := d.Set("replace", privateKey.Replace); err != nil {
+		return err
+	}
+	if err := d.Set("public_key_sha1", privateKey.PublicKeySHA1); err != nil {
+		return err
+	}
+	return nil
+}
+
+func findTLSPrivateKey(conn *fastly.Client, d *schema.ResourceData) (*fastly.PrivateKey, error) {
 	var filters []func(*fastly.PrivateKey) bool
 
 	if v, ok := d.GetOk("id"); ok {
@@ -91,45 +134,18 @@ func dataSourceTLSPrivateKeyRead(d *schema.ResourceData, meta interface{}) error
 
 	privateKeys, err := listTLSPrivateKeys(conn, filters...)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if len(privateKeys) == 0 {
-		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+		return nil, fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
 	}
 
 	if len(privateKeys) > 1 {
-		return fmt.Errorf("Your query returned more than one result. Please change to a more specific search criteria and try again.")
+		return nil, fmt.Errorf("Your query returned more than one result. Please change to a more specific search criteria and try again.")
 	}
 
-	privateKey := privateKeys[0]
-
-	d.SetId(privateKey.ID)
-	err = d.Set("name", privateKey.Name)
-	if err != nil {
-		return err
-	}
-	err = d.Set("created_at", privateKey.CreatedAt.Format(time.RFC3339))
-	if err != nil {
-		return err
-	}
-	err = d.Set("key_length", privateKey.KeyLength)
-	if err != nil {
-		return err
-	}
-	err = d.Set("key_type", privateKey.KeyType)
-	if err != nil {
-		return err
-	}
-	err = d.Set("replace", privateKey.Replace)
-	if err != nil {
-		return err
-	}
-	err = d.Set("public_key_sha1", privateKey.PublicKeySHA1)
-	if err != nil {
-		return err
-	}
-	return nil
+	return privateKeys[0], nil
 }
 
 func listTLSPrivateKeys(conn *fastly.Client, filters ...func(*fastly.PrivateKey) bool) ([]*fastly.PrivateKey, error) {

--- a/fastly/data_source_tls_private_key_test.go
+++ b/fastly/data_source_tls_private_key_test.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/stretchr/testify/require"
+
 	"strings"
 	"testing"
 )
 
-func TestAccFastlyDataSourceTLSPrivateKeyBasic(t *testing.T) {
+func TestAccFastlyDataSourceTLSPrivateKey_filters(t *testing.T) {
 	key, _, err := generateKeyAndCert()
-	if err != nil {
-		t.Fatalf("Failed to generate private key: %v", err)
-	}
+	require.NoError(t, err)
 	key = strings.ReplaceAll(key, "\n", `\n`)
 
 	name := acctest.RandomWithPrefix(testResourcePrefix)
@@ -22,7 +22,7 @@ func TestAccFastlyDataSourceTLSPrivateKeyBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFastlyDataSourceTLSPrivateKeyConfig(key, name),
+				Config: testAccFastlyDataSourceTLSPrivateKeyConfigByName(key, name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.fastly_tls_private_key.subject", "name", name),
 					resource.TestCheckResourceAttr("data.fastly_tls_private_key.subject", "key_type", "RSA"),
@@ -32,7 +32,28 @@ func TestAccFastlyDataSourceTLSPrivateKeyBasic(t *testing.T) {
 	})
 }
 
-func testAccFastlyDataSourceTLSPrivateKeyConfig(key, name string) string {
+func TestAccFastlyDataSourceTLSPrivateKey_byID(t *testing.T) {
+	key, _, err := generateKeyAndCert()
+	require.NoError(t, err)
+
+	name := acctest.RandomWithPrefix(testResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFastlyDataSourceTLSPrivateKeyConfigByID(key, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.fastly_tls_private_key.subject", "name", name),
+					resource.TestCheckResourceAttr("data.fastly_tls_private_key.subject", "key_type", "RSA"),
+				),
+			},
+		},
+	})
+}
+
+func testAccFastlyDataSourceTLSPrivateKeyConfigByName(key, name string) string {
 	return fmt.Sprintf(`
 resource "fastly_tls_private_key" "test" {
   key_pem = "%s"
@@ -41,6 +62,21 @@ resource "fastly_tls_private_key" "test" {
 
 data "fastly_tls_private_key" "subject" {
   name = fastly_tls_private_key.test.name
+}
+`, key, name)
+}
+
+func testAccFastlyDataSourceTLSPrivateKeyConfigByID(key, name string) string {
+	return fmt.Sprintf(`
+resource "fastly_tls_private_key" "test" {
+  key_pem = <<EOF
+%s
+EOF
+  name = "%s"
+}
+
+data "fastly_tls_private_key" "subject" {
+  id = fastly_tls_private_key.test.id
 }
 `, key, name)
 }

--- a/website/docs/d/tls_private_key.html.markdown
+++ b/website/docs/d/tls_private_key.html.markdown
@@ -24,13 +24,18 @@ output "private_key_needs_replacing" {
 
 ## Arguments Reference
 
-* `id` - (Optional) Fastly private key ID
+~> **Warning:** The data source's filters are applied using an **AND** boolean operator, so depending on the combination
+ of filters, they may become mutually exclusive. The exception to this is `id` which must not be specified in combination
+ with any of the others.
+
+* `id` - (Optional) Fastly private key ID. Conflicts with all the other filters.
 * `name` - (Optional) The human-readable name assigned to the private key when uploaded.
 * `key_length` - (Optional) The key length used to generate the private key.
 * `key_type` - (Optional) The algorithm used to generate the private key. Must be RSA.
 * `public_key_sha1` - (Optional) A hash of the associated public key useful for safely identifying the key.
 
-~> **Note:** If more or less than a single match is returned by the search, Terraform will fail. Ensure that your search is specific enough to return a single key.
+~> **Note:** If more or less than a single match is returned by the search, Terraform will fail. Ensure that your search
+ is specific enough to return a single key.
 
 ## Attributes Reference
 

--- a/website_src/docs/d/tls_private_key.html.markdown.tmpl
+++ b/website_src/docs/d/tls_private_key.html.markdown.tmpl
@@ -24,13 +24,18 @@ output "private_key_needs_replacing" {
 
 ## Arguments Reference
 
-* `id` - (Optional) Fastly private key ID
+~> **Warning:** The data source's filters are applied using an **AND** boolean operator, so depending on the combination
+ of filters, they may become mutually exclusive. The exception to this is `id` which must not be specified in combination
+ with any of the others.
+
+* `id` - (Optional) Fastly private key ID. Conflicts with all the other filters.
 * `name` - (Optional) The human-readable name assigned to the private key when uploaded.
 * `key_length` - (Optional) The key length used to generate the private key.
 * `key_type` - (Optional) The algorithm used to generate the private key. Must be RSA.
 * `public_key_sha1` - (Optional) A hash of the associated public key useful for safely identifying the key.
 
-~> **Note:** If more or less than a single match is returned by the search, Terraform will fail. Ensure that your search is specific enough to return a single key.
+~> **Note:** If more or less than a single match is returned by the search, Terraform will fail. Ensure that your search
+ is specific enough to return a single key.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Change the ID argument of the `fastly_tls_private_key` data source to conflict with other filters and use the `GetPrivateKey` endpoint instead.