### PR TITLE
TLS Subscription Validation resource

### DIFF
--- a/fastly/provider.go
+++ b/fastly/provider.go
@@ -48,6 +48,7 @@ func Provider() terraform.ResourceProvider {
 			"fastly_tls_private_key":                    resourceTLSPrivateKey(),
 			"fastly_tls_activation":                     resourceTLSActivation(),
 			"fastly_tls_subscription":                   resourceFastlyTLSSubscription(),
+			"fastly_tls_subscription_validation":        resourceFastlyTLSSubscriptionValidation(),
 		},
 	}
 

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -1,11 +1,13 @@
 package fastly
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/fastly/go-fastly/v2/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"time"
 )
 
 func resourceFastlyTLSSubscription() *schema.Resource {
@@ -175,6 +177,27 @@ func resourceFastlyTLSSubscriptionRead(d *schema.ResourceData, meta interface{})
 
 func resourceFastlyTLSSubscriptionDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*FastlyClient).conn
+
+	// Delete all activations on TLS Domains in the Subscription
+	for _, domain := range d.Get("domains").(*schema.Set).List() {
+		activations, err := conn.ListTLSActivations(&fastly.ListTLSActivationsInput{
+			FilterTLSDomainID: domain.(string),
+		})
+		if err != nil {
+			return err
+		}
+
+		for _, activation := range activations {
+			if activation.Domain.ID != domain.(string) {
+				return fmt.Errorf("Fastly API returned too many TLS activations for this domain (%s)", domain)
+			}
+
+			err = conn.DeleteTLSActivation(&fastly.DeleteTLSActivationInput{ID: activation.ID})
+			if err != nil {
+				return err
+			}
+		}
+	}
 
 	err := conn.DeleteTLSSubscription(&fastly.DeleteTLSSubscriptionInput{
 		ID: d.Id(),

--- a/fastly/resource_fastly_tls_subscription_validation.go
+++ b/fastly/resource_fastly_tls_subscription_validation.go
@@ -34,21 +34,9 @@ const (
 func resourceFastlyTLSSubscriptionValidationCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*FastlyClient).conn
 
-	subscriptionID := d.Get("subscription_id").(string)
-	subscription, err := conn.GetTLSSubscription(&fastly.GetTLSSubscriptionInput{
-		ID: subscriptionID,
-	})
-	if err != nil {
-		return err
-	}
-
-	if subscription.State == subscriptionStateIssued {
-		return resourceFastlyTLSSubscriptionRead(d, meta)
-	}
-
 	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		subscription, err := conn.GetTLSSubscription(&fastly.GetTLSSubscriptionInput{
-			ID: subscriptionID,
+			ID: d.Get("subscription_id").(string),
 		})
 		if err != nil {
 			return resource.NonRetryableError(err)

--- a/fastly/resource_fastly_tls_subscription_validation.go
+++ b/fastly/resource_fastly_tls_subscription_validation.go
@@ -1,0 +1,93 @@
+package fastly
+
+import (
+	"fmt"
+	"github.com/fastly/go-fastly/v2/fastly"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"time"
+)
+
+func resourceFastlyTLSSubscriptionValidation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceFastlyTLSSubscriptionValidationCreate,
+		Read:   resourceFastlyTLSSubscriptionValidationRead,
+		Delete: resourceFastlyTLSSubscriptionValidationDelete,
+		Schema: map[string]*schema.Schema{
+			"subscription_id": {
+				Type:        schema.TypeString,
+				Description: "The ID of the TLS Subscription that should be validated.",
+				Required:    true,
+				ForceNew:    true,
+			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(45 * time.Minute),
+		},
+	}
+}
+
+const (
+	subscriptionStateIssued = "issued"
+)
+
+func resourceFastlyTLSSubscriptionValidationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	subscriptionID := d.Get("subscription_id").(string)
+	subscription, err := conn.GetTLSSubscription(&fastly.GetTLSSubscriptionInput{
+		ID: subscriptionID,
+	})
+	if err != nil {
+		return err
+	}
+
+	if subscription.State == subscriptionStateIssued {
+		return resourceFastlyTLSSubscriptionRead(d, meta)
+	}
+
+	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		subscription, err := conn.GetTLSSubscription(&fastly.GetTLSSubscriptionInput{
+			ID: subscriptionID,
+		})
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		if subscription.State != subscriptionStateIssued {
+			return resource.RetryableError(fmt.Errorf("Expected subscription state to be %s but it was %s", subscriptionStateIssued, subscription.State))
+		}
+
+		err = resourceFastlyTLSSubscriptionValidationRead(d, meta)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+}
+
+func resourceFastlyTLSSubscriptionValidationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*FastlyClient).conn
+
+	subscriptionID := d.Get("subscription_id").(string)
+	subscription, err := conn.GetTLSSubscription(&fastly.GetTLSSubscriptionInput{
+		ID: subscriptionID,
+	})
+	if err != nil {
+		return err
+	}
+
+	if subscription.State != subscriptionStateIssued {
+		d.SetId("")
+	} else {
+		d.SetId(subscriptionID)
+	}
+
+	return nil
+}
+
+func resourceFastlyTLSSubscriptionValidationDelete(_ *schema.ResourceData, _ interface{}) error {
+	// Virtual resource so doesn't need deleting
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/fastly/terraform-provider-fastly
 
 go 1.14
 
-replace github.com/fastly/go-fastly/v2 v2.1.0 => github.com/opencredo/go-fastly/v2 v2.0.0-20210127124726-6dde4566ce81
+replace github.com/fastly/go-fastly/v2 v2.1.0 => github.com/opencredo/go-fastly/v2 v2.0.0-20210127165357-84b0f3d46bd8
 
 require (
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,8 @@ github.com/opencredo/go-fastly/v2 v2.0.0-20210127101404-890bd76303f3 h1:ZJC8/QOC
 github.com/opencredo/go-fastly/v2 v2.0.0-20210127101404-890bd76303f3/go.mod h1:+gom+YR+9Q5I4biSk/ZjHQGWXxqpRxC3YDVYQcRpZwQ=
 github.com/opencredo/go-fastly/v2 v2.0.0-20210127124726-6dde4566ce81 h1:63CYSvSk1OmftcI8X2lnsZYgfCO0WovtYSlwHvwXRPE=
 github.com/opencredo/go-fastly/v2 v2.0.0-20210127124726-6dde4566ce81/go.mod h1:SB5gs7154NQWBO4hy1Q76VItq4fIWHzoZUdRru1Bd14=
+github.com/opencredo/go-fastly/v2 v2.0.0-20210127165357-84b0f3d46bd8 h1:jn8sW9n+E0Dpb2veiS9VeOllxxFInFMothCKf5u17k4=
+github.com/opencredo/go-fastly/v2 v2.0.0-20210127165357-84b0f3d46bd8/go.mod h1:SB5gs7154NQWBO4hy1Q76VItq4fIWHzoZUdRru1Bd14=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/scripts/website/parse-templates.go
+++ b/scripts/website/parse-templates.go
@@ -128,6 +128,10 @@ func main() {
 			name: "tls_subscription",
 			path: docsDir + "docs/r/tls_subscription.html.markdown",
 		},
+		{
+			name: "tls_subscription_validation",
+			path: docsDir + "docs/r/tls_subscription_validation.html.markdown",
+		},
 	}
 
 	var pages = append(resourcePages, Page{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -59,7 +59,7 @@ github.com/bgentry/go-netrc/netrc
 github.com/bgentry/speakeasy
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly/v2 v2.1.0 => github.com/opencredo/go-fastly/v2 v2.0.0-20210127124726-6dde4566ce81
+# github.com/fastly/go-fastly/v2 v2.1.0 => github.com/opencredo/go-fastly/v2 v2.0.0-20210127165357-84b0f3d46bd8
 ## explicit
 github.com/fastly/go-fastly/v2/fastly
 # github.com/fatih/color v1.7.0

--- a/website/docs/r/tls_subscription_validation.html.markdown
+++ b/website/docs/r/tls_subscription_validation.html.markdown
@@ -1,0 +1,85 @@
+---
+layout: "fastly"
+page_title: "Fastly: tls_subscription_validation"
+sidebar_current: "docs-fastly-resource-tls_subscription_validation"
+description: |-
+Represents a successful validation of a Fastly TLS Subscription
+---
+
+# fastly_tls_subscription_validation
+
+This resource represents a successful validation of a Fastly TLS Subscription in concert with other resources.
+
+Most commonly, this resource is used together with a resource for a DNS record and `fastly_tls_subscription` to request a DNS validated certificate, deploy the required validation records and wait for validation to complete.
+
+~> **Warning:** This resource implements a part of the validation workflow. It does not represent a real-world entity in Fastly, therefore changing or deleting this resource on its own has no immediate effect.
+
+## Example Usage
+
+DNS Validation with AWS Route53:
+
+```hcl
+locals {
+  domain_name = "example.com"
+  challenge_fields = [for c in fastly_tls_subscription.example.tls_authorization_challenges : {
+    name    = c.record_name
+    type    = c.record_type
+    records = c.record_values
+  } if c["challenge_type"] == "managed-dns"][0]
+}
+
+data "aws_route53_zone" "test" {
+  name         = local.domain_name
+  private_zone = false
+}
+
+resource "aws_route53_record" "domain_validation" {
+  name            = local.challenge_fields.name
+  type            = local.challenge_fields.type
+  zone_id         = data.aws_route53_zone.test.id
+  allow_overwrite = true
+  records         = local.challenge_fields.records
+  ttl             = 60
+}
+
+resource "fastly_service_v1" "example" {
+  name = "example-service"
+
+  domain {
+    name = local.domain_name
+  }
+
+  backend {
+    address = "127.0.0.1"
+    name    = "localhost"
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_tls_subscription" "example" {
+  domains               = [for domain in fastly_service_v1.example.domain : domain.name]
+  certificate_authority = "lets-encrypt"
+}
+
+resource "fastly_tls_subscription_validation" "example" {
+  subscription_id = fastly_tls_subscription.example.id
+  depends_on      = [aws_route53_record.domain_validation]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `subscription_id` - (Required) The ID of the TLS Subscription that should be validated.
+
+## Attributes Reference
+
+No other attributes are available for this resource.
+
+## Timeouts
+
+`fastly_tls_subscription_validation` supports the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+* `create` - (Default `45m`) How long to wait for the subscription to be validated.

--- a/website/fastly.erb
+++ b/website/fastly.erb
@@ -83,6 +83,9 @@
                         <li<%= sidebar_current("docs-fastly-resource-tls-subscription") %>>
                             <a href="/docs/providers/fastly/r/tls_subscription.html">fastly_tls_subscription</a>
                         </li>
+                        <li<%= sidebar_current("docs-fastly-resource-tls-subscription_validation") %>>
+                            <a href="/docs/providers/fastly/r/tls_subscription_validation.html">fastly_tls_subscription_validation</a>
+                        </li>
                     </ul>
                 </li>
             </ul>

--- a/website_src/docs/r/tls_subscription_validation.html.markdown.tmpl
+++ b/website_src/docs/r/tls_subscription_validation.html.markdown.tmpl
@@ -1,0 +1,86 @@
+{{define "tls_subscription_validation"}}---
+layout: "fastly"
+page_title: "Fastly: tls_subscription_validation"
+sidebar_current: "docs-fastly-resource-tls_subscription_validation"
+description: |-
+Represents a successful validation of a Fastly TLS Subscription
+---
+
+# fastly_tls_subscription_validation
+
+This resource represents a successful validation of a Fastly TLS Subscription in concert with other resources.
+
+Most commonly, this resource is used together with a resource for a DNS record and `fastly_tls_subscription` to request a DNS validated certificate, deploy the required validation records and wait for validation to complete.
+
+~> **Warning:** This resource implements a part of the validation workflow. It does not represent a real-world entity in Fastly, therefore changing or deleting this resource on its own has no immediate effect.
+
+## Example Usage
+
+DNS Validation with AWS Route53:
+
+```hcl
+locals {
+  domain_name = "example.com"
+  challenge_fields = [for c in fastly_tls_subscription.example.tls_authorization_challenges : {
+    name    = c.record_name
+    type    = c.record_type
+    records = c.record_values
+  } if c["challenge_type"] == "managed-dns"][0]
+}
+
+data "aws_route53_zone" "test" {
+  name         = local.domain_name
+  private_zone = false
+}
+
+resource "aws_route53_record" "domain_validation" {
+  name            = local.challenge_fields.name
+  type            = local.challenge_fields.type
+  zone_id         = data.aws_route53_zone.test.id
+  allow_overwrite = true
+  records         = local.challenge_fields.records
+  ttl             = 60
+}
+
+resource "fastly_service_v1" "example" {
+  name = "example-service"
+
+  domain {
+    name = local.domain_name
+  }
+
+  backend {
+    address = "127.0.0.1"
+    name    = "localhost"
+  }
+
+  force_destroy = true
+}
+
+resource "fastly_tls_subscription" "example" {
+  domains               = [for domain in fastly_service_v1.example.domain : domain.name]
+  certificate_authority = "lets-encrypt"
+}
+
+resource "fastly_tls_subscription_validation" "example" {
+  subscription_id = fastly_tls_subscription.example.id
+  depends_on      = [aws_route53_record.domain_validation]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `subscription_id` - (Required) The ID of the TLS Subscription that should be validated.
+
+## Attributes Reference
+
+No other attributes are available for this resource.
+
+## Timeouts
+
+`fastly_tls_subscription_validation` supports the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+* `create` - (Default `45m`) How long to wait for the subscription to be validated.
+{{end}}


### PR DESCRIPTION
PR includes new `fastly_tls_subscription_validation` resource to wait for DNS validation checks to complete. Polls the subscription state until it reaches `"issued"`.

Also contains fixes for deleting the subscription after testing these resources in tandem. After validation completes, an activation is created, which needs to be deleted before the subscription.