### PR TITLE
Improve subscriptions/activations deletion conflict

### DIFF
--- a/fastly/resource_fastly_tls_activation.go
+++ b/fastly/resource_fastly_tls_activation.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"github.com/fastly/go-fastly/v2/fastly"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"log"
 	"time"
 )
 
@@ -116,6 +117,10 @@ func resourceTLSActivationDelete(d *schema.ResourceData, meta interface{}) error
 		ID: d.Id(),
 	})
 	if err != nil {
+		if httpErr, ok := err.(*fastly.HTTPError); ok && httpErr.IsNotFound() {
+			log.Printf("[WARN] Error deleting TLS activation (%s), not found. Was a TLS subscription enabled on the same domain?\n", d.Id())
+			return nil
+		}
 		return err
 	}
 

--- a/fastly/resource_fastly_tls_subscription.go
+++ b/fastly/resource_fastly_tls_subscription.go
@@ -196,28 +196,39 @@ func resourceFastlyTLSSubscriptionRead(d *schema.ResourceData, meta interface{})
 func resourceFastlyTLSSubscriptionDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*FastlyClient).conn
 
-	// Delete all activations on TLS Domains in the Subscription
-	for _, domain := range d.Get("domains").(*schema.Set).List() {
+	subscription, err := conn.GetTLSSubscription(&fastly.GetTLSSubscriptionInput{
+		ID: d.Id(),
+	})
+	if err != nil {
+		return err
+	}
+
+	// Delete any associated TLS activations using this subscription
+	if subscription.Certificates != nil && len(subscription.Certificates) > 0 {
+		certificateID := subscription.Certificates[0].ID
+
 		activations, err := conn.ListTLSActivations(&fastly.ListTLSActivationsInput{
-			FilterTLSDomainID: domain.(string),
+			FilterTLSCertificateID: certificateID,
 		})
 		if err != nil {
 			return err
 		}
 
 		for _, activation := range activations {
-			if activation.Domain.ID != domain.(string) {
-				return fmt.Errorf("Fastly API returned too many TLS activations for this domain (%s)", domain)
+			if activation.Certificate.ID != certificateID {
+				return fmt.Errorf("Fastly API returned a TLS activation for a different subscription or certificate")
 			}
 
-			err = conn.DeleteTLSActivation(&fastly.DeleteTLSActivationInput{ID: activation.ID})
+			err := conn.DeleteTLSActivation(&fastly.DeleteTLSActivationInput{
+				ID: activation.ID,
+			})
 			if err != nil {
 				return err
 			}
 		}
 	}
 
-	err := conn.DeleteTLSSubscription(&fastly.DeleteTLSSubscriptionInput{
+	err = conn.DeleteTLSSubscription(&fastly.DeleteTLSSubscriptionInput{
 		ID: d.Id(),
 	})
 	return err

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/fastly/terraform-provider-fastly
 
 go 1.14
 
-replace github.com/fastly/go-fastly/v2 v2.1.0 => github.com/opencredo/go-fastly/v2 v2.0.0-20210127165357-84b0f3d46bd8
+replace github.com/fastly/go-fastly/v2 v2.1.0 => github.com/opencredo/go-fastly/v2 v2.0.0-20210201125133-6f15e06d36ba
 
 require (
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ github.com/opencredo/go-fastly/v2 v2.0.0-20210127124726-6dde4566ce81 h1:63CYSvSk
 github.com/opencredo/go-fastly/v2 v2.0.0-20210127124726-6dde4566ce81/go.mod h1:SB5gs7154NQWBO4hy1Q76VItq4fIWHzoZUdRru1Bd14=
 github.com/opencredo/go-fastly/v2 v2.0.0-20210127165357-84b0f3d46bd8 h1:jn8sW9n+E0Dpb2veiS9VeOllxxFInFMothCKf5u17k4=
 github.com/opencredo/go-fastly/v2 v2.0.0-20210127165357-84b0f3d46bd8/go.mod h1:SB5gs7154NQWBO4hy1Q76VItq4fIWHzoZUdRru1Bd14=
+github.com/opencredo/go-fastly/v2 v2.0.0-20210201125133-6f15e06d36ba h1:c7Tl3xmd+KSv8CEc57fV0M+PFvwHqF4SbgqtjrK11A8=
+github.com/opencredo/go-fastly/v2 v2.0.0-20210201125133-6f15e06d36ba/go.mod h1:SB5gs7154NQWBO4hy1Q76VItq4fIWHzoZUdRru1Bd14=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/vendor/github.com/fastly/go-fastly/v2/fastly/platform_tls.go
+++ b/vendor/github.com/fastly/go-fastly/v2/fastly/platform_tls.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/google/jsonapi"
@@ -37,10 +38,10 @@ type TLSDomain struct {
 
 // ListBulkCertificatesInput is used as input to the ListBulkCertificates function.
 type ListBulkCertificatesInput struct {
-	PageNumber              *uint   // The page index for pagination.
-	PageSize                *uint   // The number of keys per page.
-	FilterTLSDomainsIDMatch *string // Filter certificates by their matching, fully-qualified domain name. Returns all partial matches. Must provide a value longer than 3 characters.
-	Sort                    *string // The order in which to list certificates. Valid values are created_at, not_before, not_after. May precede any value with a - for descending.
+	PageNumber              int    // The page index for pagination.
+	PageSize                int    // The number of keys per page.
+	FilterTLSDomainsIDMatch string // Filter certificates by their matching, fully-qualified domain name. Returns all partial matches. Must provide a value longer than 3 characters.
+	Sort                    string // The order in which to list certificates. Valid values are created_at, not_before, not_after. May precede any value with a - for descending.
 }
 
 // formatFilters converts user input into query parameters for filtering.
@@ -53,8 +54,15 @@ func (i *ListBulkCertificatesInput) formatFilters() map[string]string {
 		"sort":                          i.Sort,
 	}
 	for key, value := range pairings {
-		if !reflect.ValueOf(value).IsNil() {
-			result[key] = fmt.Sprintf("%v", reflect.ValueOf(value).Elem())
+		switch v := value.(type) {
+		case int:
+			if v != 0 {
+				result[key] = strconv.Itoa(v)
+			}
+		case string:
+			if v != "" {
+				result[key] = v
+			}
 		}
 	}
 	return result
@@ -124,6 +132,7 @@ func (c *Client) GetBulkCertificate(i *GetBulkCertificateInput) (*BulkCertificat
 type CreateBulkCertificateInput struct {
 	CertBlob          string              `jsonapi:"attr,cert_blob"`
 	IntermediatesBlob string              `jsonapi:"attr,intermediates_blob"`
+	AllowUntrusted    bool                `jsonapi:"attr,allow_untrusted_root"`
 	TLSConfigurations []*TLSConfiguration `jsonapi:"relation,tls_configurations,tls_configuration"`
 }
 

--- a/vendor/github.com/fastly/go-fastly/v2/fastly/tls_subscription.go
+++ b/vendor/github.com/fastly/go-fastly/v2/fastly/tls_subscription.go
@@ -11,14 +11,19 @@ import (
 
 // TLSSubscription represents a managed TLS certificate
 type TLSSubscription struct {
-	ID                   string               `jsonapi:"primary,tls_subscription"`
-	CertificateAuthority string               `jsonapi:"attr,certificate_authority"`
-	State                string               `jsonapi:"attr,state"`
-	CreatedAt            *time.Time           `jsonapi:"attr,created_at,iso8601"`
-	UpdatedAt            *time.Time           `jsonapi:"attr,updated_at,iso8601"`
-	Configuration        *TLSConfiguration    `jsonapi:"relation,tls_configuration"`
-	TLSDomains           []*TLSDomain         `jsonapi:"relation,tls_domains"`
-	Authorizations       []*TLSAuthorizations `jsonapi:"relation,tls_authorizations"`
+	ID                   string                        `jsonapi:"primary,tls_subscription"`
+	CertificateAuthority string                        `jsonapi:"attr,certificate_authority"`
+	State                string                        `jsonapi:"attr,state"`
+	CreatedAt            *time.Time                    `jsonapi:"attr,created_at,iso8601"`
+	UpdatedAt            *time.Time                    `jsonapi:"attr,updated_at,iso8601"`
+	Configuration        *TLSConfiguration             `jsonapi:"relation,tls_configuration"`
+	TLSDomains           []*TLSDomain                  `jsonapi:"relation,tls_domains"`
+	Certificates         []*TLSSubscriptionCertificate `jsonapi:"relation,tls_certificates"`
+	Authorizations       []*TLSAuthorizations          `jsonapi:"relation,tls_authorizations"`
+}
+
+type TLSSubscriptionCertificate struct {
+	ID string `jsonapi:"primary,tls_certificate"`
 }
 
 type TLSAuthorizations struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -59,7 +59,7 @@ github.com/bgentry/go-netrc/netrc
 github.com/bgentry/speakeasy
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/fastly/go-fastly/v2 v2.1.0 => github.com/opencredo/go-fastly/v2 v2.0.0-20210127165357-84b0f3d46bd8
+# github.com/fastly/go-fastly/v2 v2.1.0 => github.com/opencredo/go-fastly/v2 v2.0.0-20210201125133-6f15e06d36ba
 ## explicit
 github.com/fastly/go-fastly/v2/fastly
 # github.com/fatih/color v1.7.0


### PR DESCRIPTION
Two extra protections against problems:

- In `tls_subscription` deletion function, be more specific before deleting an associated activation; check the activation's certificate ID matches the subscription's certificate ID
- In the 'tls_activation` deletion function, ignore 404 errors from the deletion and assume a subscription deleted it already. This allows the running plan to continue executing without a `terraform state rm` intervention needed.

One issue in this PR is the logging. I have used `log.Printf` with a `[WARN]` prefix but this is only shown to the user when they use `TF_LOG=DEBUG`. I'm not sure if there's maybe a better way to do this without the updated SDK and the `diag` package?